### PR TITLE
add tryParse methods to DateFormat

### DIFF
--- a/pkgs/intl/lib/src/intl/date_format.dart
+++ b/pkgs/intl/lib/src/intl/date_format.dart
@@ -314,6 +314,21 @@ class DateFormat {
   DateTime parse(String inputString, [bool utc = false]) =>
       _parse(inputString, utc: utc, strict: false);
 
+  /// Given user input, attempt to parse the [inputString] into the anticipated
+  /// format, treating it as being in the local timezone.
+  ///
+  /// If [inputString] does not match our format, returns `null`.
+  /// This will accept dates whose values are not strictly valid, or strings
+  /// with additional characters (including whitespace) after a valid date. For
+  /// stricter parsing, use [tryParseStrict].
+  DateTime? tryParse(String inputString, [bool utc = false]) {
+    try {
+      return parse(inputString, utc);
+    } on FormatException {
+      return null;
+    }
+  }
+
   /// Given user input, attempt to parse the [inputString] 'loosely' into the
   /// anticipated format, accepting some variations from the strict format.
   ///
@@ -347,6 +362,39 @@ class DateFormat {
     }
   }
 
+  /// Given user input, attempt to parse the [inputString] 'loosely' into the
+  /// anticipated format, accepting some variations from the strict format.
+  ///
+  /// If [inputString] is accepted by [tryParseStrict], just return the result. If
+  /// not, attempt to parse it, but accepting either upper or lower case,
+  /// allowing delimiters to be missing and replaced or supplemented with
+  /// whitespace, and allowing arbitrary amounts of whitespace wherever
+  /// whitespace is permitted. Note that this does not allow trailing
+  /// characters, the way [tryParse] does.  It also does not allow alternative
+  /// names for months or weekdays other than those the format knows about. The
+  /// restrictions are quite arbitrary and it's not known how well they'll work
+  /// for locales that aren't English-like.
+  ///
+  /// If [inputString] does not parse, this returns `null`.
+  ///
+  /// For example, this will accept
+  ///
+  ///       DateFormat.yMMMd('en_US').tryParseLoose('SEp   3 2014');
+  ///       DateFormat.yMd('en_US').tryParseLoose('09    03/2014');
+  ///       DateFormat.yMd('en_US').tryParseLoose('09 / 03 / 2014');
+  ///
+  /// It will NOT accept
+  ///
+  ///       // 'Sept' is not a valid month name.
+  ///       DateFormat.yMMMd('en_US').tryParseLoose('Sept 3, 2014');
+  DateTime? tryParseLoose(String inputString, [bool utc = false]) {
+    try {
+      return parseLoose(inputString, utc);
+    } on FormatException {
+      return null;
+    }
+  }
+
   DateTime _parseLoose(String inputString, bool utc) {
     var dateFields = DateBuilder(locale, dateTimeConstructor);
     if (utc) dateFields.utc = true;
@@ -372,6 +420,22 @@ class DateFormat {
   /// looser parsing, use [parse].
   DateTime parseStrict(String inputString, [bool utc = false]) =>
       _parse(inputString, utc: utc, strict: true);
+
+  /// Given user input, attempt to parse the [inputString] into the anticipated
+  /// format, treating it as being in the local timezone.
+  ///
+  /// If [inputString] does not match our format, returns `null`.
+  /// This will reject dates whose values are not strictly valid, even if the
+  /// DateTime constructor will accept them. It will also reject strings with
+  /// additional characters (including whitespace) after a valid date. For
+  /// looser parsing, use [tryParse].
+  DateTime? tryParseStrict(String inputString, [bool utc = false]) {
+    try {
+      return parseStrict(inputString, utc);
+    } on FormatException {
+      return null;
+    }
+  }
 
   DateTime _parse(String inputString, {bool utc = false, bool strict = false}) {
     // TODO(alanknight): The Closure code refers to special parsing of numeric
@@ -400,6 +464,7 @@ class DateFormat {
 
   /// Given user input, attempt to parse the [inputString] into the anticipated
   /// format, treating it as being in UTC.
+  /// If [inputString] does not match our format, throws a [FormatException].
   ///
   /// The canonical Dart style name
   /// is [parseUtc], but [parseUTC] is retained
@@ -408,11 +473,23 @@ class DateFormat {
 
   /// Given user input, attempt to parse the [inputString] into the anticipated
   /// format, treating it as being in UTC.
+  /// If [inputString] does not match our format, throws a [FormatException].
   ///
   /// The canonical Dart style name
   /// is [parseUtc], but [parseUTC] is retained
   /// for backward-compatibility.
   DateTime parseUtc(String inputString) => parse(inputString, true);
+
+  /// Given user input, attempt to parse the [inputString] into the anticipated
+  /// format, treating it as being in UTC.
+  /// If [inputString] does not match our format, returns `null`.
+  DateTime? tryParseUtc(String inputString) {
+    try {
+      return parseUtc(inputString);
+    } on FormatException {
+      return null;
+    }
+  }
 
   /// Return the locale code in which we operate, e.g. 'en_US' or 'pt'.
   String get locale => _locale;

--- a/pkgs/intl/test/date_time_loose_parsing_test.dart
+++ b/pkgs/intl/test/date_time_loose_parsing_test.dart
@@ -16,55 +16,55 @@ import 'package:test/test.dart';
 void main() {
   late DateFormat format;
 
-  var date = DateTime(2014, 9, 3);
+  group('DateFormat#parseLoose', () {
+    var date = DateTime(2014, 9, 3);
 
-  void check(String s) {
-    expect(() => format.parse(s), throwsFormatException);
-    expect(format.parseLoose(s), date);
-  }
+    void check(String s) {
+      expect(() => format.parse(s), throwsFormatException);
+      expect(format.parseLoose(s), date);
+    }
 
-  test('Loose parsing yMMMd', () {
-    // Note: We can't handle e.g. Sept, we don't have those abbreviations
-    // in our data.
-    // Also doesn't handle 'sep3,2014', or 'sep 3.2014'
-    format = DateFormat.yMMMd('en_US');
-    check('Sep 3 2014');
-    check('sep 3 2014');
-    check('sep 3  2014');
-    check('sep  3 2014');
-    check('sep  3       2014');
-    check('sep3 2014');
-    check('september 3, 2014');
-    check('sEPTembER 3, 2014');
-    check('seP 3, 2014');
-    check('Sep 3,2014');
-  });
+    test('Loose parsing yMMMd', () {
+      // Note: We can't handle e.g. Sept, we don't have those abbreviations
+      // in our data.
+      // Also doesn't handle 'sep3,2014', or 'sep 3.2014'
+      format = DateFormat.yMMMd('en_US');
+      check('Sep 3 2014');
+      check('sep 3 2014');
+      check('sep 3  2014');
+      check('sep  3 2014');
+      check('sep  3       2014');
+      check('sep3 2014');
+      check('september 3, 2014');
+      check('sEPTembER 3, 2014');
+      check('seP 3, 2014');
+      check('Sep 3,2014');
+    });
 
-  test('Loose parsing yMMMd that parses strict', () {
-    expect(format.parseLoose('Sep 3, 2014'), date);
-  });
+    test('Loose parsing yMMMd that parses strict', () {
+      expect(format.parseLoose('Sep 3, 2014'), date);
+    });
 
-  test('Loose parsing yMd', () {
-    format = DateFormat.yMd('en_US');
-    check('09 3 2014');
-    check('09 00003    2014');
-    check('09/    03/2014');
-    check('09 / 03 / 2014');
-  });
+    test('Loose parsing yMd', () {
+      format = DateFormat.yMd('en_US');
+      check('09 3 2014');
+      check('09 00003    2014');
+      check('09/    03/2014');
+      check('09 / 03 / 2014');
+    });
 
-  test('Loose parsing yMd that parses strict', () {
-    expect(format.parseLoose('09/03/2014'), date);
-    expect(format.parseLoose('09/3/2014'), date);
-  });
+    test('Loose parsing yMd that parses strict', () {
+      expect(format.parseLoose('09/03/2014'), date);
+      expect(format.parseLoose('09/3/2014'), date);
+    });
 
-  test('Loose parsing should handle standalone month format', () {
-    // This checks that LL actually sets the month.
-    // The appended whitespace and extra d pattern are present to trigger the
-    // loose parsing code path.
-    expect(DateFormat('LL/d', 'en_US').parseLoose('05/ 2').month, 5);
-  });
+    test('Loose parsing should handle standalone month format', () {
+      // This checks that LL actually sets the month.
+      // The appended whitespace and extra d pattern are present to trigger the
+      // loose parsing code path.
+      expect(DateFormat('LL/d', 'en_US').parseLoose('05/ 2').month, 5);
+    });
 
-  group('Loose parsing with year formats', () {
     test('should fail when year is omitted (en_US)', () {
       expect(() => DateFormat('yyyy-MM-dd').parseLoose('1/11'),
           throwsFormatException);
@@ -100,6 +100,80 @@ void main() {
           throwsFormatException);
       expect(() => DateFormat.yMMMMEEEEd('hu').parseLoose('3. 17.'),
           throwsFormatException);
+    });
+  });
+
+  group('DateFormat#tryParseLoose', () {
+    var date = DateTime(2014, 9, 3);
+
+    void check(String s) {
+      expect(format.tryParse(s), isNull);
+      expect(format.tryParseLoose(s), date);
+    }
+
+    test('Loose parsing yMMMd', () {
+      // Note: We can't handle e.g. Sept, we don't have those abbreviations
+      // in our data.
+      // Also doesn't handle 'sep3,2014', or 'sep 3.2014'
+      format = DateFormat.yMMMd('en_US');
+      check('Sep 3 2014');
+      check('sep 3 2014');
+      check('sep 3  2014');
+      check('sep  3 2014');
+      check('sep  3       2014');
+      check('sep3 2014');
+      check('september 3, 2014');
+      check('sEPTembER 3, 2014');
+      check('seP 3, 2014');
+      check('Sep 3,2014');
+    });
+
+    test('Loose parsing yMMMd that parses strict', () {
+      expect(format.tryParseLoose('Sep 3, 2014'), date);
+    });
+
+    test('Loose parsing yMd', () {
+      format = DateFormat.yMd('en_US');
+      check('09 3 2014');
+      check('09 00003    2014');
+      check('09/    03/2014');
+      check('09 / 03 / 2014');
+    });
+
+    test('Loose parsing yMd that parses strict', () {
+      expect(format.tryParseLoose('09/03/2014'), date);
+      expect(format.tryParseLoose('09/3/2014'), date);
+    });
+
+    test('Loose parsing should handle standalone month format', () {
+      // This checks that LL actually sets the month.
+      // The appended whitespace and extra d pattern are present to trigger the
+      // loose parsing code path.
+      expect(DateFormat('LL/d', 'en_US').tryParseLoose('05/ 2')?.month, 5);
+    });
+
+    test('should fail when year is omitted (en_US)', () {
+      expect(DateFormat('yyyy-MM-dd').tryParseLoose('1/11'), isNull);
+    });
+
+    test('should fail when year is omitted (ja)', () {
+      initializeDateFormatting('ja', null);
+      expect(DateFormat.yMMMd('ja').tryParseLoose('12月12日'), isNull);
+      expect(DateFormat.yMd('ja').tryParseLoose('12月12日'), isNull);
+      expect(DateFormat.yMEd('ja').tryParseLoose('12月12日'), isNull);
+      expect(DateFormat.yMMMEd('ja').tryParseLoose('12月12日'), isNull);
+      expect(DateFormat.yMMMMd('ja').tryParseLoose('12月12日'), isNull);
+      expect(DateFormat.yMMMMEEEEd('ja').tryParseLoose('12月12日'), isNull);
+    });
+
+    test('should fail when year is omitted (hu)', () {
+      initializeDateFormatting('hu', null);
+      expect(DateFormat.yMMMd('hu').tryParseLoose('3. 17.'), isNull);
+      expect(DateFormat.yMd('hu').tryParseLoose('3. 17.'), isNull);
+      expect(DateFormat.yMEd('hu').tryParseLoose('3. 17.'), isNull);
+      expect(DateFormat.yMMMEd('hu').tryParseLoose('3. 17.'), isNull);
+      expect(DateFormat.yMMMMd('hu').tryParseLoose('3. 17.'), isNull);
+      expect(DateFormat.yMMMMEEEEd('hu').tryParseLoose('3. 17.'), isNull);
     });
   });
 }

--- a/pkgs/intl/test/date_time_strict_test.dart
+++ b/pkgs/intl/test/date_time_strict_test.dart
@@ -85,4 +85,81 @@ void main() {
     check('14:0:60');
     expect(format.parseStrict('14:0:59'), DateTime(1970, 1, 1, 14, 0, 59));
   });
+
+  group('DateFormat#tryParseStrict', () {
+    test('All input consumed', () {
+      var format = DateFormat.yMMMd();
+      var date = DateTime(2014, 9, 3);
+      var formatted = 'Sep 3, 2014';
+      expect(format.format(date), formatted);
+      var parsed = format.tryParseStrict(formatted);
+      expect(parsed, date);
+
+      void check(String s) {
+        expect(format.tryParseStrict(s), isNull);
+        expect(format.tryParse(s), date);
+      }
+
+      check('$formatted,');
+      check('${formatted}abc');
+      check('$formatted   ');
+    });
+
+    test('Invalid dates', () {
+      var format = DateFormat.yMd();
+      void check(s) => expect(format.tryParseStrict(s), isNull);
+      check('0/3/2014');
+      check('13/3/2014');
+      check('9/0/2014');
+      check('9/31/2014');
+      check('09/31/2014');
+      check('10/32/2014');
+      check('2/29/2014');
+      check('1/32/2014');
+      expect(format.tryParseStrict('2/29/2016'), DateTime(2016, 2, 29));
+    });
+
+    test('Valid ordinal date is not rejected', () {
+      var dayOfYearFormat = DateFormat('MM/DD/yyyy');
+      expect(dayOfYearFormat.tryParseStrict('1/32/2014'), DateTime(2014, 2, 1));
+    });
+
+    test('Invalid times am/pm', () {
+      const space = '\u202F';
+      var format = DateFormat.jms();
+      void check(s) => expect(format.tryParseStrict(s), isNull);
+      check('-1:15:00 AM');
+      expect(format.tryParseStrict('0:15:00${space}AM'),
+          DateTime(1970, 1, 1, 0, 15));
+      check('24:00:00 PM');
+      check('24:00:00 AM');
+      check('25:00:00 PM');
+      check('0:-1:00 AM');
+      check('0:60:00 AM');
+      expect(format.tryParseStrict('0:59:00${space}AM'),
+          DateTime(1970, 1, 1, 0, 59));
+      check('0:0:-1 AM');
+      check('0:0:60 AM');
+      check('2:0:60 PM');
+      expect(format.tryParseStrict('2:0:59${space}PM'),
+          DateTime(1970, 1, 1, 14, 0, 59));
+    });
+
+    test('Invalid times 24 hour', () {
+      var format = DateFormat.Hms();
+      void check(s) => expect(format.tryParseStrict(s), isNull);
+      check('-1:15:00');
+      expect(format.tryParseStrict('0:15:00'), DateTime(1970, 1, 1, 0, 15));
+      check('24:00:00');
+      check('24:00:00');
+      check('25:00:00');
+      check('0:-1:00');
+      check('0:60:00');
+      expect(format.tryParseStrict('0:59:00'), DateTime(1970, 1, 1, 0, 59));
+      check('0:0:-1');
+      check('0:0:60');
+      check('14:0:60');
+      expect(format.tryParseStrict('14:0:59'), DateTime(1970, 1, 1, 14, 0, 59));
+    });
+  });
 }


### PR DESCRIPTION
- tryParse
- tryParseStrict
- tryParseLoose
- tryParseUtc
- add tests

related issue https://github.com/dart-lang/i18n/issues/191

original pr https://github.com/dart-lang/intl/pull/578