### PR TITLE
Fix mistaken copybara imports

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.18.1-dev
-
-* Update ruble sign and update corresponding test
-* Remove unimplemented timezone functionality
+## 0.18.1
+ * Update ruble sign and update corresponding test.
+ * Remove unimplemented timezone functionality.
+ * Update git path in pubspec.
 
 ## 0.18.0
  * Add support for `minimumSignificantDigits` / `maximumSignificantDigits` in

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,10 +1,10 @@
 name: intl
-version: 0.18.1-dev
+version: 0.18.1
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other
   internationalization issues.
-repository: https://github.com/dart-lang/intl
+repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Apparently there was some error introduced by the migration to a monorepo, leading to copybara overwriting some changes. This reverts them.