### PR TITLE
Add stub for conditional export

### DIFF
--- a/pkgs/intl/lib/find_locale.dart
+++ b/pkgs/intl/lib/find_locale.dart
@@ -1,4 +1,5 @@
 export 'src/intl_default.dart' // Stub implementation
     // Browser implementation
     if (dart.library.html) 'intl_browser.dart'
+    // Native implementation
     if (dart.library.io) 'intl_standalone.dart';

--- a/pkgs/intl/lib/intl_default.dart
+++ b/pkgs/intl/lib/intl_default.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// This provides facilities for Internationalization that are only available
+/// when running in the web browser. You should import only one of this or
+/// intl_standalone.dart. Right now the only thing provided here is the
+/// ability to find the default locale from the browser.
+
+Future<String> findSystemLocale() => throw UnimplementedError(
+    'This is a stub for either `intl_standalone` or `intl_browser`');


### PR DESCRIPTION
Fix the missing stub for the conditional export in `find_locale.dart`.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for a week or two of latency for initial review feedback.

---
