### PR TITLE
Add intl4x list format

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -6,3 +6,5 @@ on:
 jobs:
   health:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    with:
+      coverage_web: true

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Add list format.
+
 ## 0.1.0
 
 - Initial version.

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -14,7 +14,7 @@ A lightweight modular library for internationalization (i18n) functionality.
 ## Status
 |   | Number format  | List format  | Date format  | Collation  | Display names |
 |---|:---:|:---:|:---:|:---:|:---:|
-| **ECMA402 (web)** | :heavy_check_mark: |   |   | :heavy_check_mark: |   |
+| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: |   | :heavy_check_mark: |   |
 | **ICU4X (web/native)**  |   |   |   |   |   | 
 
 

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -8,6 +8,9 @@ import 'src/collation/collation_impl.dart';
 import 'src/data.dart';
 import 'src/ecma/ecma_policy.dart';
 import 'src/ecma/ecma_stub.dart' if (dart.library.js) 'src/ecma/ecma_web.dart';
+import 'src/list_format/list_format.dart';
+import 'src/list_format/list_format_impl.dart';
+import 'src/list_format/list_format_options.dart';
 import 'src/locale.dart';
 import 'src/number_format/number_format.dart';
 import 'src/number_format/number_format_impl.dart';
@@ -47,6 +50,11 @@ class Intl {
   NumberFormat numberFormat([NumberFormatOptions? options]) => NumberFormat(
         options ?? NumberFormatOptions.custom(),
         NumberFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
+      );
+
+  ListFormat listFormat([ListFormatOptions? options]) => ListFormat(
+        options ?? const ListFormatOptions(),
+        ListFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
       );
 
   /// Construct an [Intl] instance providing the current [currentLocale] and the

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -12,7 +12,6 @@ import 'src/list_format/list_format.dart';
 import 'src/list_format/list_format_impl.dart';
 import 'src/list_format/list_format_options.dart';
 import 'src/locale.dart';
-import 'src/number_format/number_format.dart';
 import 'src/number_format/number_format_impl.dart';
 import 'src/options.dart';
 

--- a/pkgs/intl4x/lib/list_format.dart
+++ b/pkgs/intl4x/lib/list_format.dart
@@ -2,5 +2,5 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/number_format/number_format.dart';
-export 'src/number_format/number_format_options.dart';
+export 'src/list_format/list_format.dart';
+export 'src/list_format/list_format_options.dart';

--- a/pkgs/intl4x/lib/src/list_format/list_format.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format.dart
@@ -13,7 +13,7 @@ class ListFormat {
 
   const ListFormat(this._options, this._listFormatImpl);
 
-  /// Locale-dependant concatenation of lists, for example in `en-US` locale
+  /// Locale-dependant concatenation of lists, for example in `en-US` locale:
   /// ```dart
   /// format(['A', 'B', 'C']) == 'A, B, and C'
   /// ```

--- a/pkgs/intl4x/lib/src/list_format/list_format.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format.dart
@@ -8,9 +8,10 @@ import 'list_format_impl.dart';
 import 'list_format_options.dart';
 
 class ListFormat {
+  final ListFormatOptions _options;
   final ListFormatImpl _listFormatImpl;
 
-  const ListFormat(this._listFormatImpl);
+  const ListFormat(this._options, this._listFormatImpl);
 
   /// Locale-dependant concatenation of lists, for example in `en-US` locale
   /// ```dart
@@ -25,12 +26,7 @@ class ListFormat {
     if (isInTest) {
       return '${list.join(', ')}-${_listFormatImpl.locale}';
     } else {
-      return _listFormatImpl.formatImpl(
-        list,
-        localeMatcher: localeMatcher,
-        type: type,
-        style: style,
-      );
+      return _listFormatImpl.formatImpl(list, _options);
     }
   }
 }

--- a/pkgs/intl4x/lib/src/list_format/list_format.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format.dart
@@ -24,7 +24,7 @@ class ListFormat {
     ListStyle style = ListStyle.long,
   }) {
     if (isInTest) {
-      return '${list.join(', ')}-${_listFormatImpl.locale}';
+      return '${list.join(', ')}//${_listFormatImpl.locale}';
     } else {
       return _listFormatImpl.formatImpl(list, _options);
     }

--- a/pkgs/intl4x/lib/src/list_format/list_format.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../options.dart';
+import '../test_checker.dart';
+import 'list_format_impl.dart';
+import 'list_format_options.dart';
+
+class ListFormat {
+  final ListFormatImpl _listFormatImpl;
+
+  const ListFormat(this._listFormatImpl);
+
+  /// Locale-dependant concatenation of lists, for example in `en-US` locale
+  /// ```dart
+  /// format(['A', 'B', 'C']) == 'A, B, and C'
+  /// ```
+  String format(
+    List<String> list, {
+    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
+    Type type = Type.conjunction,
+    ListStyle style = ListStyle.long,
+  }) {
+    if (isInTest) {
+      return '${list.join(', ')}-${_listFormatImpl.locale}';
+    } else {
+      return _listFormatImpl.formatImpl(
+        list,
+        localeMatcher: localeMatcher,
+        type: type,
+        style: style,
+      );
+    }
+  }
+}

--- a/pkgs/intl4x/lib/src/list_format/list_format_4x.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_4x.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale.dart';
+import '../options.dart';
+import 'list_format_impl.dart';
+import 'list_format_options.dart';
+
+ListFormatImpl getListFormatter4X(Locale locale) => ListFormat4X(locale);
+
+class ListFormat4X extends ListFormatImpl {
+  ListFormat4X(super.locale);
+
+  @override
+  String formatImpl(
+    List<String> list, {
+    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
+    Type type = Type.conjunction,
+    ListStyle style = ListStyle.long,
+  }) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+}

--- a/pkgs/intl4x/lib/src/list_format/list_format_4x.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_4x.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../locale.dart';
-import '../options.dart';
 import 'list_format_impl.dart';
 import 'list_format_options.dart';
 
@@ -13,12 +12,7 @@ class ListFormat4X extends ListFormatImpl {
   ListFormat4X(super.locale);
 
   @override
-  String formatImpl(
-    List<String> list, {
-    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
-    Type type = Type.conjunction,
-    ListStyle style = ListStyle.long,
-  }) {
+  String formatImpl(List<String> list, ListFormatOptions options) {
     throw UnimplementedError('Insert diplomat bindings here');
   }
 }

--- a/pkgs/intl4x/lib/src/list_format/list_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_ecma.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+import '../locale.dart';
+import '../options.dart';
+import '../utils.dart';
+import 'list_format_impl.dart';
+import 'list_format_options.dart';
+
+ListFormatImpl? getListFormatterECMA(
+  Locale locale,
+  LocaleMatcher localeMatcher,
+) =>
+    _ListFormatECMA.tryToBuild(locale, localeMatcher);
+
+@JS('Intl.ListFormat')
+class ListFormatJS {
+  external factory ListFormatJS([List<String> locale, Object options]);
+  external String format(List<String> list);
+}
+
+@JS('Intl.ListFormat.supportedLocalesOf')
+external List<String> supportedLocalesOfJS(
+  List<String> listOfLocales, [
+  Object options,
+]);
+
+class _ListFormatECMA extends ListFormatImpl {
+  _ListFormatECMA(super.locales);
+
+  static ListFormatImpl? tryToBuild(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+  ) {
+    final supportedLocales = supportedLocalesOf(locale, localeMatcher);
+    return supportedLocales.isNotEmpty
+        ? _ListFormatECMA(supportedLocales.first)
+        : null;
+  }
+
+  static List<String> supportedLocalesOf(
+    String locale,
+    LocaleMatcher localeMatcher,
+  ) {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    return List.from(supportedLocalesOfJS([localeToJsFormat(locale)], o));
+  }
+
+  @override
+  String formatImpl(
+    List<String> list, {
+    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
+    Type type = Type.conjunction,
+    ListStyle style = ListStyle.long,
+  }) {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    setProperty(o, 'type', type.name);
+    setProperty(o, 'style', style.name);
+    return ListFormatJS([localeToJsFormat(locale)], o).format(list);
+  }
+}

--- a/pkgs/intl4x/lib/src/list_format/list_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_ecma.dart
@@ -52,16 +52,18 @@ class _ListFormatECMA extends ListFormatImpl {
   }
 
   @override
-  String formatImpl(
-    List<String> list, {
-    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
-    Type type = Type.conjunction,
-    ListStyle style = ListStyle.long,
-  }) {
+  String formatImpl(List<String> list, ListFormatOptions options) {
+    return ListFormatJS([localeToJsFormat(locale)], options.toJsOptions())
+        .format(list);
+  }
+}
+
+extension on ListFormatOptions {
+  Object toJsOptions() {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);
     setProperty(o, 'type', type.name);
     setProperty(o, 'style', style.name);
-    return ListFormatJS([localeToJsFormat(locale)], o).format(list);
+    return o;
   }
 }

--- a/pkgs/intl4x/lib/src/list_format/list_format_impl.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_impl.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import '../../ecma_policy.dart';
 import '../ecma/ecma_policy.dart';
 import '../locale.dart';

--- a/pkgs/intl4x/lib/src/list_format/list_format_impl.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_impl.dart
@@ -1,0 +1,34 @@
+import '../../ecma_policy.dart';
+import '../ecma/ecma_policy.dart';
+import '../locale.dart';
+import '../options.dart';
+import '../utils.dart';
+import 'list_format_4x.dart';
+import 'list_format_options.dart';
+import 'list_format_stub.dart' if (dart.library.js) 'list_format_ecma.dart';
+
+abstract class ListFormatImpl {
+  final Locale locale;
+
+  ListFormatImpl(this.locale);
+
+  String formatImpl(
+    List<String> list, {
+    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
+    Type type = Type.conjunction,
+    ListStyle style = ListStyle.long,
+  });
+
+  factory ListFormatImpl.build(
+    Locale locales,
+    LocaleMatcher localeMatcher,
+    EcmaPolicy ecmaPolicy,
+  ) =>
+      buildFormatter(
+        locales,
+        localeMatcher,
+        ecmaPolicy,
+        getListFormatterECMA,
+        getListFormatter4X,
+      );
+}

--- a/pkgs/intl4x/lib/src/list_format/list_format_impl.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_impl.dart
@@ -12,12 +12,7 @@ abstract class ListFormatImpl {
 
   ListFormatImpl(this.locale);
 
-  String formatImpl(
-    List<String> list, {
-    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
-    Type type = Type.conjunction,
-    ListStyle style = ListStyle.long,
-  });
+  String formatImpl(List<String> list, ListFormatOptions options);
 
   factory ListFormatImpl.build(
     Locale locales,

--- a/pkgs/intl4x/lib/src/list_format/list_format_options.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_options.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Indicates the type of grouping.
+enum Type {
+  /// For "and"-based grouping of the list items: "A, B, and C"
+  conjunction,
+
+  /// For "or"-based grouping of the list items: "A, B, or C"
+  disjunction,
+
+  /// Grouping the list items as a unit: "A, B, C"
+  unit;
+}
+
+/// Indicates the grouping style (for example, whether list separators and
+/// conjunctions are included).
+enum ListStyle {
+  /// Example: "A, B, and C"
+  long,
+
+  /// Example: "A, B, C"
+  short,
+
+  /// Example: "A B C"
+  narrow;
+}

--- a/pkgs/intl4x/lib/src/list_format/list_format_options.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_options.dart
@@ -2,6 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../options.dart';
+
+class ListFormatOptions {
+  final Type type;
+  final ListStyle style;
+  final LocaleMatcher localeMatcher;
+
+  const ListFormatOptions({
+    this.type = Type.conjunction,
+    this.style = ListStyle.long,
+    this.localeMatcher = LocaleMatcher.bestfit,
+  });
+}
+
 /// Indicates the type of grouping.
 enum Type {
   /// For "and"-based grouping of the list items: "A, B, and C"

--- a/pkgs/intl4x/lib/src/list_format/list_format_options.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_options.dart
@@ -18,25 +18,25 @@ class ListFormatOptions {
 
 /// Indicates the type of grouping.
 enum Type {
-  /// For "and"-based grouping of the list items: "A, B, and C"
+  /// For "and"-based grouping of the list items: "A, B, and C".
   conjunction,
 
-  /// For "or"-based grouping of the list items: "A, B, or C"
+  /// For "or"-based grouping of the list items: "A, B, or C".
   disjunction,
 
-  /// Grouping the list items as a unit: "A, B, C"
+  /// Grouping the list items as a unit: "A, B, C".
   unit;
 }
 
 /// Indicates the grouping style (for example, whether list separators and
 /// conjunctions are included).
 enum ListStyle {
-  /// Example: "A, B, and C"
+  /// Example: "A, B, and C".
   long,
 
-  /// Example: "A, B, C"
+  /// Example: "A, B, C".
   short,
 
-  /// Example: "A B C"
+  /// Example: "A B C".
   narrow;
 }

--- a/pkgs/intl4x/lib/src/list_format/list_format_stub.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_stub.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale.dart';
+import '../options.dart';
+import 'list_format_impl.dart';
+
+ListFormatImpl? getListFormatterECMA(
+  Locale locale,
+  LocaleMatcher localeMatcher,
+) =>
+    throw UnimplementedError('Cannot use ECMA outside of web environments.');

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 
 environment:

--- a/pkgs/intl4x/test/ecma/list_format_test.dart
+++ b/pkgs/intl4x/test/ecma/list_format_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:intl4x/ecma_policy.dart';
+import 'package:intl4x/intl4x.dart';
+import 'package:intl4x/src/list_format/list_format_options.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  group('List style options', () {
+    final list = ['A', 'B', 'C'];
+    final intl = Intl(defaultLocale: 'en_US');
+    testWithFormatting('long', () {
+      final listFormat =
+          intl.listFormat(const ListFormatOptions(style: ListStyle.long));
+      expect(listFormat.format(list), 'A, B, and C');
+    });
+    testWithFormatting('short', () {
+      final listFormat =
+          intl.listFormat(const ListFormatOptions(style: ListStyle.short));
+      expect(listFormat.format(list), 'A, B, & C');
+    });
+    testWithFormatting('narrow', () {
+      final listFormat =
+          intl.listFormat(const ListFormatOptions(style: ListStyle.narrow));
+      expect(listFormat.format(list), 'A, B, C');
+    });
+  });
+
+  group('List type options', () {
+    final list = ['A', 'B', 'C'];
+    final intl = Intl(defaultLocale: 'en_US');
+    testWithFormatting('long', () {
+      final listFormat =
+          intl.listFormat(const ListFormatOptions(type: Type.conjunction));
+      expect(listFormat.format(list), 'A, B, and C');
+    });
+    testWithFormatting('short', () {
+      final listFormat =
+          intl.listFormat(const ListFormatOptions(type: Type.disjunction));
+      expect(listFormat.format(list), 'A, B, or C');
+    });
+    testWithFormatting('narrow', () {
+      final listFormat =
+          intl.listFormat(const ListFormatOptions(type: Type.unit));
+      expect(listFormat.format(list), 'A, B, C');
+    });
+  });
+
+  group('List style and type combinations', () {
+    final list = ['A', 'B', 'C'];
+    final intl = Intl(ecmaPolicy: const AlwaysEcma(), defaultLocale: 'en_US');
+    testWithFormatting('long', () {
+      final formatter = intl.listFormat(const ListFormatOptions(
+          style: ListStyle.narrow, type: Type.conjunction));
+      expect(formatter.format(list), 'A, B, C');
+    });
+    testWithFormatting('short', () {
+      final formatter = intl.listFormat(
+          const ListFormatOptions(style: ListStyle.short, type: Type.unit));
+      expect(formatter.format(list), 'A, B, C');
+    });
+  });
+}

--- a/pkgs/intl4x/test/icu4x/list_format_test.dart
+++ b/pkgs/intl4x/test/icu4x/list_format_test.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:intl4x/intl4x.dart';
+import 'package:intl4x/list_format.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  final list = ['A', 'B', 'C'];
+  test('Does not compare in tests', () {
+    final locale = 'de_DE';
+    final listFormatGerman = Intl(defaultLocale: locale)
+        .listFormat(const ListFormatOptions(style: ListStyle.long));
+    expect(listFormatGerman.format(list), '${list.join(', ')}//$locale');
+  });
+
+  testWithFormatting('long', () {
+    final intl = Intl(defaultLocale: 'en_US');
+    final listFormat =
+        intl.listFormat(const ListFormatOptions(style: ListStyle.long));
+    expect(() => listFormat.format(list), throwsA(isA<UnimplementedError>()));
+  });
+}


### PR DESCRIPTION
Add list formatting from ECMA402.

Regarding the failing health workflow: I am deferring to adding the missing license header as a test of https://github.com/dart-lang/ecosystem/pull/134; when this is merged I will add and see if the check then passes.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
