### PR TITLE
Add ECMA402 display names

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Add display names.
+
 ## 0.2.0
 
 - Add list format.

--- a/pkgs/intl4x/lib/display_names.dart
+++ b/pkgs/intl4x/lib/display_names.dart
@@ -1,0 +1,6 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/display_names/display_names.dart';
+export 'src/display_names/display_names_options.dart';

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -3,9 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'collation.dart';
+import 'display_names.dart';
 import 'number_format.dart';
 import 'src/collation/collation_impl.dart';
 import 'src/data.dart';
+import 'src/display_names/display_names_impl.dart';
 import 'src/ecma/ecma_policy.dart';
 import 'src/ecma/ecma_stub.dart' if (dart.library.js) 'src/ecma/ecma_web.dart';
 import 'src/list_format/list_format.dart';
@@ -54,6 +56,11 @@ class Intl {
   ListFormat listFormat([ListFormatOptions? options]) => ListFormat(
         options ?? const ListFormatOptions(),
         ListFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
+      );
+
+  DisplayNames displayNames([DisplayNamesOptions? options]) => DisplayNames(
+        options ?? const DisplayNamesOptions(),
+        DisplayNamesImpl.build(currentLocale, localeMatcher, ecmaPolicy),
       );
 
   /// Construct an [Intl] instance providing the current [currentLocale] and the

--- a/pkgs/intl4x/lib/src/display_names/display_names.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names.dart
@@ -9,30 +9,30 @@ import 'display_names_impl.dart';
 
 class DisplayNames {
   final DisplayNamesOptions _options;
-  final DisplayNamesImpl impl;
+  final DisplayNamesImpl _impl;
 
-  DisplayNames(this._options, this.impl);
+  DisplayNames(this._options, this._impl);
 
-  String _of(String object, DisplayType type) {
+  String ofDateTime(DateTimeField field) => _of(field, _impl.ofDateTime);
+
+  String ofLanguage(Locale locale) => _of(locale, _impl.ofLanguage);
+
+  String ofRegion(String regionCode) => _of(regionCode, _impl.ofRegion);
+
+  String ofScript(String scriptCode) => _of(scriptCode, _impl.ofScript);
+
+  String ofCurrency(String currencyCode) => _of(currencyCode, _impl.ofCurrency);
+
+  String ofCalendar(Calendar calendar) => _of(calendar, _impl.ofCalendar);
+
+  String _of<T>(
+    T object,
+    String Function(T field, DisplayNamesOptions options) implementation,
+  ) {
     if (isInTest) {
-      return '$object//${impl.locale}';
+      return '$object//${_impl.locale}';
     } else {
-      return impl.ofImpl(object, _options, type);
+      return implementation(object, _options);
     }
   }
-
-  String ofDateTime(DateTimeField field) =>
-      _of(field.name, DisplayType.dateTimeField);
-
-  String ofLanguage(Locale locale) => _of(locale, DisplayType.language);
-
-  String ofRegion(String regionCode) => _of(regionCode, DisplayType.region);
-
-  String ofScript(String scriptCode) => _of(scriptCode, DisplayType.script);
-
-  String ofCurrency(String currencyCode) =>
-      _of(currencyCode, DisplayType.currency);
-
-  String ofCalendar(Calendar calendar) =>
-      _of(calendar.jsName, DisplayType.calendar);
 }

--- a/pkgs/intl4x/lib/src/display_names/display_names.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../display_names.dart';
+import '../locale.dart';
 import '../test_checker.dart';
 import 'display_names_impl.dart';
 
@@ -12,11 +13,26 @@ class DisplayNames {
 
   DisplayNames(this._options, this.impl);
 
-  String of(String object) {
+  String _of(String object, DisplayType type) {
     if (isInTest) {
       return '$object//${impl.locale}';
     } else {
-      return impl.ofImpl(object, _options);
+      return impl.ofImpl(object, _options, type);
     }
   }
+
+  String ofDateTime(DateTimeField field) =>
+      _of(field.name, DisplayType.dateTimeField);
+
+  String ofLanguage(Locale locale) => _of(locale, DisplayType.language);
+
+  String ofRegion(String regionCode) => _of(regionCode, DisplayType.region);
+
+  String ofScript(String scriptCode) => _of(scriptCode, DisplayType.script);
+
+  String ofCurrency(String currencyCode) =>
+      _of(currencyCode, DisplayType.currency);
+
+  String ofCalendar(Calendar calendar) =>
+      _of(calendar.jsName, DisplayType.calendar);
 }

--- a/pkgs/intl4x/lib/src/display_names/display_names.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../display_names.dart';
+import '../test_checker.dart';
+import 'display_names_impl.dart';
+
+class DisplayNames {
+  final DisplayNamesOptions _options;
+  final DisplayNamesImpl impl;
+
+  DisplayNames(this._options, this.impl);
+
+  String of(String object) {
+    if (isInTest) {
+      return '$object//${impl.locale}';
+    } else {
+      return impl.ofImpl(object, _options);
+    }
+  }
+}

--- a/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
@@ -12,7 +12,7 @@ class DisplayNames4X extends DisplayNamesImpl {
   DisplayNames4X(super.locale);
 
   @override
-  String ofImpl(Object number, DisplayNamesOptions options) {
+  String ofImpl(String object, DisplayNamesOptions options, DisplayType type) {
     throw UnimplementedError('Insert diplomat bindings here');
   }
 }

--- a/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
@@ -12,7 +12,32 @@ class DisplayNames4X extends DisplayNamesImpl {
   DisplayNames4X(super.locale);
 
   @override
-  String ofImpl(String object, DisplayNamesOptions options, DisplayType type) {
+  String ofCalendar(Calendar calendar, DisplayNamesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+
+  @override
+  String ofCurrency(String currencyCode, DisplayNamesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+
+  @override
+  String ofDateTime(DateTimeField field, DisplayNamesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+
+  @override
+  String ofLanguage(Locale locale, DisplayNamesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+
+  @override
+  String ofRegion(String regionCode, DisplayNamesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+
+  @override
+  String ofScript(String scriptCode, DisplayNamesOptions options) {
     throw UnimplementedError('Insert diplomat bindings here');
   }
 }

--- a/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale.dart';
+import 'display_names_impl.dart';
+import 'display_names_options.dart';
+
+DisplayNamesImpl getDisplayNames4X(Locale locale) => DisplayNames4X(locale);
+
+class DisplayNames4X extends DisplayNamesImpl {
+  DisplayNames4X(super.locale);
+
+  @override
+  String ofImpl(Object number, DisplayNamesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+}

--- a/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
@@ -52,14 +52,37 @@ class _DisplayNamesECMA extends DisplayNamesImpl {
     return List.from(_supportedLocalesOfJS([localeToJsFormat(locale)], o));
   }
 
-  @override
-  String ofImpl(String object, DisplayNamesOptions options, DisplayType type) {
+  String of(DisplayNamesOptions options, DisplayType type, String jsName) {
     final displayNamesJS = _DisplayNamesJS(
       [localeToJsFormat(locale)],
       options.toJsOptions(type),
     );
-    return displayNamesJS.of(object);
+    return displayNamesJS.of(jsName);
   }
+
+  @override
+  String ofCalendar(Calendar calendar, DisplayNamesOptions options) =>
+      of(options, DisplayType.calendar, calendar.jsName);
+
+  @override
+  String ofCurrency(String currencyCode, DisplayNamesOptions options) =>
+      of(options, DisplayType.currency, currencyCode);
+
+  @override
+  String ofDateTime(DateTimeField field, DisplayNamesOptions options) =>
+      of(options, DisplayType.dateTimeField, field.name);
+
+  @override
+  String ofLanguage(Locale locale, DisplayNamesOptions options) =>
+      of(options, DisplayType.language, locale);
+
+  @override
+  String ofRegion(String regionCode, DisplayNamesOptions options) =>
+      of(options, DisplayType.region, regionCode);
+
+  @override
+  String ofScript(String scriptCode, DisplayNamesOptions options) =>
+      of(options, DisplayType.script, scriptCode);
 }
 
 extension on DisplayNamesOptions {

--- a/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
@@ -21,7 +21,7 @@ DisplayNamesImpl? getDisplayNamesECMA(
 @JS('Intl.DisplayNames')
 class _DisplayNamesJS {
   external factory _DisplayNamesJS([List<String> locale, Object options]);
-  external String format(Object num);
+  external String of(String object);
 }
 
 @JS('Intl.DisplayNames.supportedLocalesOf')
@@ -53,17 +53,17 @@ class _DisplayNamesECMA extends DisplayNamesImpl {
   }
 
   @override
-  String ofImpl(Object number, DisplayNamesOptions options) {
-    final numberFormatJS = _DisplayNamesJS(
+  String ofImpl(String object, DisplayNamesOptions options, DisplayType type) {
+    final displayNamesJS = _DisplayNamesJS(
       [localeToJsFormat(locale)],
-      options.toJsOptions(),
+      options.toJsOptions(type),
     );
-    return numberFormatJS.format(number);
+    return displayNamesJS.of(object);
   }
 }
 
 extension on DisplayNamesOptions {
-  Object toJsOptions() {
+  Object toJsOptions(DisplayType type) {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);
     setProperty(o, 'style', style.name);

--- a/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+import '../locale.dart';
+import '../options.dart';
+@JS()
+import '../utils.dart';
+import 'display_names_impl.dart';
+import 'display_names_options.dart';
+
+DisplayNamesImpl? getDisplayNamesECMA(
+  Locale locale,
+  LocaleMatcher localeMatcher,
+) =>
+    _DisplayNamesECMA.tryToBuild(locale, localeMatcher);
+
+@JS('Intl.DisplayNames')
+class _DisplayNamesJS {
+  external factory _DisplayNamesJS([List<String> locale, Object options]);
+  external String format(Object num);
+}
+
+@JS('Intl.DisplayNames.supportedLocalesOf')
+external List<String> _supportedLocalesOfJS(
+  List<String> listOfLocales, [
+  Object options,
+]);
+
+class _DisplayNamesECMA extends DisplayNamesImpl {
+  _DisplayNamesECMA(super.locales);
+
+  static DisplayNamesImpl? tryToBuild(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+  ) {
+    final supportedLocales = supportedLocalesOf(localeMatcher, locale);
+    return supportedLocales.isNotEmpty
+        ? _DisplayNamesECMA(supportedLocales.first)
+        : null; //TODO: Add support to force return an instance instead of null.
+  }
+
+  static List<String> supportedLocalesOf(
+    LocaleMatcher localeMatcher,
+    Locale locale,
+  ) {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    return List.from(_supportedLocalesOfJS([localeToJsFormat(locale)], o));
+  }
+
+  @override
+  String ofImpl(Object number, DisplayNamesOptions options) {
+    final numberFormatJS = _DisplayNamesJS(
+      [localeToJsFormat(locale)],
+      options.toJsOptions(),
+    );
+    return numberFormatJS.format(number);
+  }
+}
+
+extension on DisplayNamesOptions {
+  Object toJsOptions() {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    setProperty(o, 'style', style.name);
+    setProperty(o, 'type', type.name);
+    setProperty(o, 'languageDisplay', languageDisplay.name);
+    setProperty(o, 'fallback', fallback.name);
+    return o;
+  }
+}

--- a/pkgs/intl4x/lib/src/display_names/display_names_impl.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_impl.dart
@@ -17,7 +17,17 @@ abstract class DisplayNamesImpl {
 
   DisplayNamesImpl(this.locale);
 
-  String ofImpl(String object, DisplayNamesOptions options, DisplayType type);
+  String ofDateTime(DateTimeField field, DisplayNamesOptions options);
+
+  String ofLanguage(Locale locale, DisplayNamesOptions options);
+
+  String ofRegion(String regionCode, DisplayNamesOptions options);
+
+  String ofScript(String scriptCode, DisplayNamesOptions options);
+
+  String ofCurrency(String currencyCode, DisplayNamesOptions options);
+
+  String ofCalendar(Calendar calendar, DisplayNamesOptions options);
 
   factory DisplayNamesImpl.build(
     Locale locale,

--- a/pkgs/intl4x/lib/src/display_names/display_names_impl.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_impl.dart
@@ -11,13 +11,13 @@ import 'display_names_options.dart';
 import 'display_names_stub.dart' if (dart.library.js) 'display_names_ecma.dart';
 
 /// This is an intermediate to defer to the actual implementations of
-/// Number formatting.
+/// Display naming.
 abstract class DisplayNamesImpl {
   final String locale;
 
   DisplayNamesImpl(this.locale);
 
-  String ofImpl(Object number, DisplayNamesOptions options);
+  String ofImpl(String object, DisplayNamesOptions options, DisplayType type);
 
   factory DisplayNamesImpl.build(
     Locale locale,

--- a/pkgs/intl4x/lib/src/display_names/display_names_impl.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_impl.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../ecma/ecma_policy.dart';
+import '../locale.dart';
+import '../options.dart';
+import '../utils.dart';
+import 'display_names_4x.dart';
+import 'display_names_options.dart';
+import 'display_names_stub.dart' if (dart.library.js) 'display_names_ecma.dart';
+
+/// This is an intermediate to defer to the actual implementations of
+/// Number formatting.
+abstract class DisplayNamesImpl {
+  final String locale;
+
+  DisplayNamesImpl(this.locale);
+
+  String ofImpl(Object number, DisplayNamesOptions options);
+
+  factory DisplayNamesImpl.build(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+    EcmaPolicy ecmaPolicy,
+  ) =>
+      buildFormatter(
+        locale,
+        localeMatcher,
+        ecmaPolicy,
+        getDisplayNamesECMA,
+        getDisplayNames4X,
+      );
+}

--- a/pkgs/intl4x/lib/src/display_names/display_names_options.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_options.dart
@@ -6,14 +6,12 @@ import '../options.dart';
 
 /// Display names options for the browser.
 class DisplayNamesOptions {
-  final DisplayType type;
   final Style style;
   final LanguageDisplay languageDisplay;
   final Fallback fallback;
   final LocaleMatcher localeMatcher;
 
-  DisplayNamesOptions({
-    required this.type,
+  const DisplayNamesOptions({
     this.style = Style.long,
     this.languageDisplay = LanguageDisplay.dialect,
     this.fallback = Fallback.code,
@@ -44,4 +42,45 @@ enum LanguageDisplay {
 enum Fallback {
   code,
   none,
+}
+
+enum DateTimeField {
+  era,
+  year,
+  month,
+  quarter,
+  weekOfYear,
+  weekday,
+  dayPeriod,
+  day,
+  hour,
+  minute,
+  second,
+}
+
+enum Calendar {
+  buddhist,
+  chinese,
+  coptic,
+  dangi,
+  ethioaa,
+  ethiopic,
+  gregory,
+  hebrew,
+  indian,
+  islamic,
+  islamicUmalqura('islamic-umalqura'),
+  islamicTbla('islamic-tbla'),
+  islamicCivil('islamic-civil'),
+  islamicRgsa('islamic-rgsa'),
+  iso8601,
+  japanese,
+  persian,
+  roc;
+
+  String get jsName => _jsName ?? name;
+
+  final String? _jsName;
+
+  const Calendar([this._jsName]);
 }

--- a/pkgs/intl4x/lib/src/display_names/display_names_options.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_options.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../options.dart';
+
+/// Display names options for the browser.
+class DisplayNamesOptions {
+  final DisplayType type;
+  final Style style;
+  final LanguageDisplay languageDisplay;
+  final Fallback fallback;
+  final LocaleMatcher localeMatcher;
+
+  DisplayNamesOptions({
+    required this.type,
+    this.style = Style.long,
+    this.languageDisplay = LanguageDisplay.dialect,
+    this.fallback = Fallback.code,
+    this.localeMatcher = LocaleMatcher.bestfit,
+  });
+}
+
+enum Style {
+  narrow,
+  short,
+  long,
+}
+
+enum DisplayType {
+  calendar,
+  currency,
+  dateTimeField,
+  language,
+  region,
+  script,
+}
+
+enum LanguageDisplay {
+  dialect,
+  standard,
+}
+
+enum Fallback {
+  code,
+  none,
+}

--- a/pkgs/intl4x/lib/src/display_names/display_names_stub.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_stub.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale.dart';
+import '../options.dart';
+import 'display_names_impl.dart';
+
+DisplayNamesImpl? getDisplayNamesECMA(
+  Locale locales,
+  LocaleMatcher localeMatcher,
+) =>
+    throw UnimplementedError('Cannot use ECMA outside of web environments.');

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 
 environment:

--- a/pkgs/intl4x/test/ecma/display_names_test.dart
+++ b/pkgs/intl4x/test/ecma/display_names_test.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:intl4x/display_names.dart';
+import 'package:intl4x/intl4x.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWithFormatting('basic', () {
+    expect(Intl(defaultLocale: 'en_US').displayNames().ofLanguage('de-DE'),
+        'German (Germany)');
+  });
+
+  testWithFormatting('languageDisplay', () {
+    String of(DisplayNamesOptions options) =>
+        Intl(defaultLocale: 'en').displayNames(options).ofLanguage('en-GB');
+
+    expect(
+      of(const DisplayNamesOptions(languageDisplay: LanguageDisplay.dialect)),
+      'British English',
+    );
+    expect(
+      of(const DisplayNamesOptions(languageDisplay: LanguageDisplay.standard)),
+      'English (United Kingdom)',
+    );
+  });
+
+  testWithFormatting('calendar', () {
+    final displayNames = Intl(defaultLocale: 'en').displayNames();
+
+    expect(displayNames.ofCalendar(Calendar.roc), 'Minguo Calendar');
+    expect(displayNames.ofCalendar(Calendar.gregory), 'Gregorian Calendar');
+    expect(displayNames.ofCalendar(Calendar.chinese), 'Chinese Calendar');
+  });
+
+  testWithFormatting('dateTimeField', () {
+    final displayNames = Intl(defaultLocale: 'pt').displayNames();
+    expect(displayNames.ofDateTime(DateTimeField.era), 'era');
+    expect(displayNames.ofDateTime(DateTimeField.year), 'ano');
+    expect(displayNames.ofDateTime(DateTimeField.month), 'mês');
+    expect(displayNames.ofDateTime(DateTimeField.quarter), 'trimestre');
+    expect(displayNames.ofDateTime(DateTimeField.weekOfYear), 'semana');
+    expect(displayNames.ofDateTime(DateTimeField.weekday), 'dia da semana');
+    expect(displayNames.ofDateTime(DateTimeField.dayPeriod), 'AM/PM');
+    expect(displayNames.ofDateTime(DateTimeField.day), 'dia');
+    expect(displayNames.ofDateTime(DateTimeField.hour), 'hora');
+    expect(displayNames.ofDateTime(DateTimeField.minute), 'minuto');
+    expect(displayNames.ofDateTime(DateTimeField.second), 'segundo');
+  });
+}

--- a/pkgs/intl4x/test/ecma/display_names_test.dart
+++ b/pkgs/intl4x/test/ecma/display_names_test.dart
@@ -53,4 +53,25 @@ void main() {
     expect(displayNames.ofDateTime(DateTimeField.minute), 'minuto');
     expect(displayNames.ofDateTime(DateTimeField.second), 'segundo');
   });
+
+  testWithFormatting('currency', () {
+    expect(
+      Intl(defaultLocale: 'pt').displayNames().ofCurrency('USD'),
+      'Dólar americano',
+    );
+  });
+
+  testWithFormatting('script', () {
+    expect(
+      Intl(defaultLocale: 'fr').displayNames().ofScript('Egyp'),
+      'hiéroglyphes égyptiens',
+    );
+  });
+
+  testWithFormatting('region', () {
+    expect(
+      Intl(defaultLocale: 'es-419').displayNames().ofRegion('DE'),
+      'Alemania',
+    );
+  });
 }


### PR DESCRIPTION
Add the browser's display names feature.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
