### PR TITLE
Add ECMA402 datetime format to package:intl4x

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -5,6 +5,6 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@a52ac638c03b8f2356c2ab9168ff27f83b379177
     with:
       coverage_web: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
+    tags: [ '[0-9A-z]+-v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   publish:

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Add datetime formatting.
+
 ## 0.3.0
 
 - Add display names.

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -14,7 +14,7 @@ A lightweight modular library for internationalization (i18n) functionality.
 ## Status
 |   | Number format  | List format  | Date format  | Collation  | Display names |
 |---|:---:|:---:|:---:|:---:|:---:|
-| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: |   | :heavy_check_mark: |   |
+| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | **ICU4X (web/native)**  |   |   |   |   |   | 
 
 

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -17,7 +17,7 @@ via our [issue tracker](https://github.com/dart-lang/i18n/issues)).
 
 |   | Number format  | List format  | Date format  | Collation  | Display names |
 |---|:---:|:---:|:---:|:---:|:---:|
-| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  | :heavy_check_mark: |
+| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | **ICU4X (web/native)**  |   |   |   |   |   | 
 
 ## Implementation and Goals

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -36,10 +36,12 @@ import 'package:intl4x/ecma_policy.dart';
 import 'package:intl4x/intl4x.dart';
 import 'package:intl4x/number_format.dart';
 
-final numberFormat = Intl(
-  ecmaPolicy: const AlwaysEcma(),
-  defaultLocale: Locale(language: 'en', country: 'US'),
-).numberFormat(NumberFormatOptions.percent());
+void main() {
+  final numberFormat = Intl(
+    ecmaPolicy: const AlwaysEcma(),
+    locale: const Locale(language: 'en', region: 'US'),
+  ).numberFormat(NumberFormatOptions.percent());
 
-print(numberFormat.format(0.5)); // prints 50%
+  print(numberFormat.format(0.5)); // prints 50%
+}
 ```

--- a/pkgs/intl4x/lib/collation.dart
+++ b/pkgs/intl4x/lib/collation.dart
@@ -4,3 +4,4 @@
 
 export 'src/collation/collation.dart';
 export 'src/collation/collation_options.dart';
+export 'src/options.dart';

--- a/pkgs/intl4x/lib/datetime_format.dart
+++ b/pkgs/intl4x/lib/datetime_format.dart
@@ -2,6 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/display_names/display_names.dart';
-export 'src/display_names/display_names_options.dart';
+export 'src/datetime_format/datetime_format.dart';
+export 'src/datetime_format/datetime_format_options.dart';
 export 'src/options.dart';

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -65,10 +65,10 @@ class Intl {
         DisplayNamesImpl.build(currentLocale, localeMatcher, ecmaPolicy),
       );
 
-  DatetimeFormat datetimeFormat([DatetimeFormatOptions? options]) =>
-      DatetimeFormat(
-        options ?? const DatetimeFormatOptions(),
-        DatetimeFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
+  DateTimeFormat datetimeFormat([DateTimeFormatOptions? options]) =>
+      DateTimeFormat(
+        options ?? const DateTimeFormatOptions(),
+        DateTimeFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
       );
 
   /// Construct an [Intl] instance providing the current [currentLocale] and the

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -18,7 +18,6 @@ import 'src/list_format/list_format_impl.dart';
 import 'src/list_format/list_format_options.dart';
 import 'src/locale.dart';
 import 'src/number_format/number_format_impl.dart';
-import 'src/options.dart';
 
 typedef Icu4xKey = String;
 

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -6,6 +6,9 @@ import 'collation.dart';
 import 'number_format.dart';
 import 'src/collation/collation_impl.dart';
 import 'src/data.dart';
+import 'src/datetime_format/datetime_format.dart';
+import 'src/datetime_format/datetime_format_impl.dart';
+import 'src/datetime_format/datetime_format_options.dart';
 import 'src/ecma/ecma_policy.dart';
 import 'src/ecma/ecma_stub.dart' if (dart.library.js) 'src/ecma/ecma_web.dart';
 import 'src/list_format/list_format.dart';
@@ -54,6 +57,12 @@ class Intl {
   ListFormat listFormat([ListFormatOptions? options]) => ListFormat(
         options ?? const ListFormatOptions(),
         ListFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
+      );
+
+  DatetimeFormat datetimeFormat([DatetimeFormatOptions? options]) =>
+      DatetimeFormat(
+        options ?? const DatetimeFormatOptions(),
+        DatetimeFormatImpl.build(currentLocale, localeMatcher, ecmaPolicy),
       );
 
   /// Construct an [Intl] instance providing the current [currentLocale] and the

--- a/pkgs/intl4x/lib/list_format.dart
+++ b/pkgs/intl4x/lib/list_format.dart
@@ -4,3 +4,4 @@
 
 export 'src/list_format/list_format.dart';
 export 'src/list_format/list_format_options.dart';
+export 'src/options.dart';

--- a/pkgs/intl4x/lib/number_format.dart
+++ b/pkgs/intl4x/lib/number_format.dart
@@ -4,3 +4,4 @@
 
 export 'src/number_format/number_format.dart';
 export 'src/number_format/number_format_options.dart';
+export 'src/options.dart';

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
@@ -6,11 +6,11 @@ import '../test_checker.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
 
-class DatetimeFormat {
-  final DatetimeFormatOptions _options;
-  final DatetimeFormatImpl impl;
+class DateTimeFormat {
+  final DateTimeFormatOptions _options;
+  final DateTimeFormatImpl impl;
 
-  DatetimeFormat(this._options, this.impl);
+  DateTimeFormat(this._options, this.impl);
 
   String format(DateTime datetime) {
     if (isInTest) {

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../test_checker.dart';
+import 'datetime_format_impl.dart';
+import 'datetime_format_options.dart';
+
+class DatetimeFormat {
+  final DatetimeFormatOptions _options;
+  final DatetimeFormatImpl impl;
+
+  DatetimeFormat(this._options, this.impl);
+
+  String format(DateTime datetime) {
+    if (isInTest) {
+      return '$datetime//${impl.locale}';
+    } else {
+      return impl.formatImpl(datetime, _options);
+    }
+  }
+}

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
@@ -6,6 +6,19 @@ import '../test_checker.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
 
+/// `DateTime` formatting, for example:
+///
+/// ```dart
+/// final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
+/// Intl(locale: const Locale(language: 'fr'))
+///     .datetimeFormat(const DateTimeFormatOptions(
+///       hour: TimeRepresentation.numeric,
+///       hourCycle: HourCycle.h12,
+///       dayPeriod: DayPeriod.narrow,
+///       timeZone: 'UTC',
+///     ))
+///     .format(date); // Output: '4 mat.'
+/// ```
 class DateTimeFormat {
   final DateTimeFormatOptions _options;
   final DateTimeFormatImpl impl;

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_4x.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_4x.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale.dart';
+import 'datetime_format_impl.dart';
+import 'datetime_format_options.dart';
+
+DatetimeFormatImpl getDatetimeFormatter4X(Locale locale) =>
+    DatetimeFormat4X(locale);
+
+class DatetimeFormat4X extends DatetimeFormatImpl {
+  DatetimeFormat4X(super.locale);
+
+  @override
+  String formatImpl(DateTime datetime, DatetimeFormatOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+}

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_4x.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_4x.dart
@@ -6,14 +6,14 @@ import '../locale.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
 
-DatetimeFormatImpl getDatetimeFormatter4X(Locale locale) =>
-    DatetimeFormat4X(locale);
+DateTimeFormatImpl getDateTimeFormatter4X(Locale locale) =>
+    DateTimeFormat4X(locale);
 
-class DatetimeFormat4X extends DatetimeFormatImpl {
-  DatetimeFormat4X(super.locale);
+class DateTimeFormat4X extends DateTimeFormatImpl {
+  DateTimeFormat4X(super.locale);
 
   @override
-  String formatImpl(DateTime datetime, DatetimeFormatOptions options) {
+  String formatImpl(DateTime datetime, DateTimeFormatOptions options) {
     throw UnimplementedError('Insert diplomat bindings here');
   }
 }

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -105,10 +105,12 @@ extension on DateTimeFormatOptions {
   Object toJsOptions() {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);
-    if (dateFormatStyle != null)
+    if (dateFormatStyle != null) {
       setProperty(o, 'dateStyle', dateFormatStyle!.name);
-    if (timeFormatStyle != null)
+    }
+    if (timeFormatStyle != null) {
       setProperty(o, 'timeStyle', timeFormatStyle!.name);
+    }
     if (calendar != null) setProperty(o, 'calendar', calendar!.jsName);
     if (dayPeriod != null) setProperty(o, 'dayPeriod', dayPeriod!.name);
     if (numberingSystem != null) {

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -11,15 +11,15 @@ import '../utils.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
 
-DatetimeFormatImpl? getDatetimeFormatterECMA(
+DateTimeFormatImpl? getDateTimeFormatterECMA(
   Locale locale,
   LocaleMatcher localeMatcher,
 ) =>
-    _DatetimeFormatECMA.tryToBuild(locale, localeMatcher);
+    _DateTimeFormatECMA.tryToBuild(locale, localeMatcher);
 
 @JS('Intl.DateTimeFormat')
-class _DatetimeFormatJS {
-  external factory _DatetimeFormatJS([List<String> locale, Object options]);
+class _DateTimeFormatJS {
+  external factory _DateTimeFormatJS([List<String> locale, Object options]);
   external String format(Object num);
 }
 
@@ -56,16 +56,16 @@ external int UTC(
   int milliseconds,
 );
 
-class _DatetimeFormatECMA extends DatetimeFormatImpl {
-  _DatetimeFormatECMA(super.locales);
+class _DateTimeFormatECMA extends DateTimeFormatImpl {
+  _DateTimeFormatECMA(super.locales);
 
-  static DatetimeFormatImpl? tryToBuild(
+  static DateTimeFormatImpl? tryToBuild(
     Locale locale,
     LocaleMatcher localeMatcher,
   ) {
     final supportedLocales = supportedLocalesOf(localeMatcher, locale);
     return supportedLocales.isNotEmpty
-        ? _DatetimeFormatECMA(supportedLocales.first)
+        ? _DateTimeFormatECMA(supportedLocales.first)
         : null; //TODO: Add support to force return an instance instead of null.
   }
 
@@ -79,8 +79,8 @@ class _DatetimeFormatECMA extends DatetimeFormatImpl {
   }
 
   @override
-  String formatImpl(DateTime datetime, DatetimeFormatOptions options) {
-    final datetimeFormatJS = _DatetimeFormatJS(
+  String formatImpl(DateTime datetime, DateTimeFormatOptions options) {
+    final datetimeFormatJS = _DateTimeFormatJS(
       [localeToJsFormat(locale)],
       options.toJsOptions(),
     );
@@ -99,7 +99,7 @@ extension on DateTime {
   }
 }
 
-extension on DatetimeFormatOptions {
+extension on DateTimeFormatOptions {
   Object toJsOptions() {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -7,7 +7,6 @@ import 'package:js/js_util.dart';
 
 import '../locale.dart';
 import '../options.dart';
-@JS()
 import '../utils.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
@@ -41,17 +40,21 @@ class DateJS {
     int seconds,
     int milliseconds,
   );
-  // ignore: non_constant_identifier_names
-  external factory DateJS.UTC(
-    int year,
-    int monthIndex,
-    int day,
-    int hours,
-    int minutes,
-    int seconds,
-    int milliseconds,
-  );
+
+  external factory DateJS.fromTimeStamp(int timeStamp);
 }
+
+@JS('Date.UTC')
+// ignore: non_constant_identifier_names
+external int UTC(
+  int year,
+  int monthIndex,
+  int day,
+  int hours,
+  int minutes,
+  int seconds,
+  int milliseconds,
+);
 
 class _DatetimeFormatECMA extends DatetimeFormatImpl {
   _DatetimeFormatECMA(super.locales);
@@ -88,9 +91,10 @@ class _DatetimeFormatECMA extends DatetimeFormatImpl {
 extension on DateTime {
   DateJS toJs() {
     if (isUtc) {
-      return DateJS.UTC(year, month, day, hour, minute, second, millisecond);
+      return DateJS.fromTimeStamp(
+          UTC(year, month - 1, day, hour, minute, second, millisecond));
     } else {
-      return DateJS(year, month, day, hour, minute, second, millisecond);
+      return DateJS(year, month - 1, day, hour, minute, second, millisecond);
     }
   }
 }
@@ -99,6 +103,31 @@ extension on DatetimeFormatOptions {
   Object toJsOptions() {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    if (dateStyle != null) setProperty(o, 'dateStyle', dateStyle!.name);
+    if (timeStyle != null) setProperty(o, 'timeStyle', timeStyle!.name);
+    if (calendar != null) setProperty(o, 'calendar', calendar!.jsName);
+    if (dayPeriod != null) setProperty(o, 'dayPeriod', dayPeriod!.name);
+    if (numberingSystem != null) {
+      setProperty(o, 'numberingSystem', numberingSystem!.name);
+    }
+    if (timeZone != null) setProperty(o, 'timeZone', timeZone!);
+    if (hour12 ?? false) setProperty(o, 'hour12', true);
+    if (hourCycle != null) setProperty(o, 'hourCycle', hourCycle!.name);
+    if (weekday != null) setProperty(o, 'weekday', weekday!.name);
+    if (era != null) setProperty(o, 'era', era!.name);
+    if (year != null) setProperty(o, 'year', year!.jsName);
+    if (month != null) setProperty(o, 'month', month!.jsName);
+    if (day != null) setProperty(o, 'day', day!.jsName);
+    if (hour != null) setProperty(o, 'hour', hour!.jsName);
+    if (minute != null) setProperty(o, 'minute', minute!.jsName);
+    if (second != null) setProperty(o, 'second', second!.jsName);
+    if (fractionalSecondDigits != null) {
+      setProperty(o, 'fractionalSecondDigits', fractionalSecondDigits!);
+    }
+    if (timeZoneName != null) {
+      setProperty(o, 'timeZoneName', timeZoneName!.name);
+    }
+    setProperty(o, 'formatMatcher', formatMatcher.jsName);
     return o;
   }
 }

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -7,7 +7,6 @@ import 'package:js/js_util.dart';
 
 import '../locale.dart';
 import '../options.dart';
-import '../utils.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
 
@@ -57,7 +56,7 @@ external int UTC(
 );
 
 class _DateTimeFormatECMA extends DateTimeFormatImpl {
-  _DateTimeFormatECMA(super.locales);
+  _DateTimeFormatECMA(super.locale);
 
   static DateTimeFormatImpl? tryToBuild(
     Locale locale,
@@ -69,19 +68,22 @@ class _DateTimeFormatECMA extends DateTimeFormatImpl {
         : null; //TODO: Add support to force return an instance instead of null.
   }
 
-  static List<String> supportedLocalesOf(
+  static List<Locale> supportedLocalesOf(
     LocaleMatcher localeMatcher,
     Locale locale,
   ) {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);
-    return List.from(_supportedLocalesOfJS([localeToJsFormat(locale)], o));
+    return List.from(_supportedLocalesOfJS([locale.toLanguageTag()], o))
+        .whereType<String>()
+        .map(Locale.parse)
+        .toList();
   }
 
   @override
   String formatImpl(DateTime datetime, DateTimeFormatOptions options) {
     final datetimeFormatJS = _DateTimeFormatJS(
-      [localeToJsFormat(locale)],
+      [locale.toLanguageTag()],
       options.toJsOptions(),
     );
     return datetimeFormatJS.format(datetime.toJs());

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+import '../locale.dart';
+import '../options.dart';
+@JS()
+import '../utils.dart';
+import 'datetime_format_impl.dart';
+import 'datetime_format_options.dart';
+
+DatetimeFormatImpl? getDatetimeFormatterECMA(
+  Locale locale,
+  LocaleMatcher localeMatcher,
+) =>
+    _DatetimeFormatECMA.tryToBuild(locale, localeMatcher);
+
+@JS('Intl.DateTimeFormat')
+class _DatetimeFormatJS {
+  external factory _DatetimeFormatJS([List<String> locale, Object options]);
+  external String format(Object num);
+}
+
+@JS('Intl.DateTimeFormat.supportedLocalesOf')
+external List<String> _supportedLocalesOfJS(
+  List<String> listOfLocales, [
+  Object options,
+]);
+
+@JS('Date')
+class DateJS {
+  external factory DateJS(
+    int year,
+    int monthIndex,
+    int day,
+    int hours,
+    int minutes,
+    int seconds,
+    int milliseconds,
+  );
+  // ignore: non_constant_identifier_names
+  external factory DateJS.UTC(
+    int year,
+    int monthIndex,
+    int day,
+    int hours,
+    int minutes,
+    int seconds,
+    int milliseconds,
+  );
+}
+
+class _DatetimeFormatECMA extends DatetimeFormatImpl {
+  _DatetimeFormatECMA(super.locales);
+
+  static DatetimeFormatImpl? tryToBuild(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+  ) {
+    final supportedLocales = supportedLocalesOf(localeMatcher, locale);
+    return supportedLocales.isNotEmpty
+        ? _DatetimeFormatECMA(supportedLocales.first)
+        : null; //TODO: Add support to force return an instance instead of null.
+  }
+
+  static List<String> supportedLocalesOf(
+    LocaleMatcher localeMatcher,
+    Locale locale,
+  ) {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    return List.from(_supportedLocalesOfJS([localeToJsFormat(locale)], o));
+  }
+
+  @override
+  String formatImpl(DateTime datetime, DatetimeFormatOptions options) {
+    final datetimeFormatJS = _DatetimeFormatJS(
+      [localeToJsFormat(locale)],
+      options.toJsOptions(),
+    );
+    return datetimeFormatJS.format(datetime.toJs());
+  }
+}
+
+extension on DateTime {
+  DateJS toJs() {
+    if (isUtc) {
+      return DateJS.UTC(year, month, day, hour, minute, second, millisecond);
+    } else {
+      return DateJS(year, month, day, hour, minute, second, millisecond);
+    }
+  }
+}
+
+extension on DatetimeFormatOptions {
+  Object toJsOptions() {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    return o;
+  }
+}

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -105,16 +105,22 @@ extension on DateTimeFormatOptions {
   Object toJsOptions() {
     final o = newObject<Object>();
     setProperty(o, 'localeMatcher', localeMatcher.jsName);
-    if (dateStyle != null) setProperty(o, 'dateStyle', dateStyle!.name);
-    if (timeStyle != null) setProperty(o, 'timeStyle', timeStyle!.name);
+    if (dateFormatStyle != null)
+      setProperty(o, 'dateStyle', dateFormatStyle!.name);
+    if (timeFormatStyle != null)
+      setProperty(o, 'timeStyle', timeFormatStyle!.name);
     if (calendar != null) setProperty(o, 'calendar', calendar!.jsName);
     if (dayPeriod != null) setProperty(o, 'dayPeriod', dayPeriod!.name);
     if (numberingSystem != null) {
       setProperty(o, 'numberingSystem', numberingSystem!.name);
     }
     if (timeZone != null) setProperty(o, 'timeZone', timeZone!);
-    if (hour12 ?? false) setProperty(o, 'hour12', true);
-    if (hourCycle != null) setProperty(o, 'hourCycle', hourCycle!.name);
+    if (clockstyle != null) {
+      setProperty(o, 'hour12', clockstyle!.is12Hour);
+      if (clockstyle!.startAtZero != null) {
+        setProperty(o, 'hourCycle', clockstyle!.hourStyleJsString());
+      }
+    }
     if (weekday != null) setProperty(o, 'weekday', weekday!.name);
     if (era != null) setProperty(o, 'era', era!.name);
     if (year != null) setProperty(o, 'year', year!.jsName);
@@ -131,5 +137,22 @@ extension on DateTimeFormatOptions {
     }
     setProperty(o, 'formatMatcher', formatMatcher.jsName);
     return o;
+  }
+}
+
+extension on ClockStyle {
+  String hourStyleJsString() {
+    // The four possible values are h11, h12, h23, h24.
+    final firstDigit = is12Hour ? 1 : 2;
+
+    final subtrahend = startAtZero! ? 1 : 0;
+    final secondDigit = firstDigit * 2 - subtrahend;
+
+    /// The cases are
+    /// * firstDigit == 1 && subtrahend == 1  --> h11
+    /// * firstDigit == 1 && subtrahend == 0  --> h12
+    /// * firstDigit == 2 && subtrahend == 1  --> h23
+    /// * firstDigit == 2 && subtrahend == 0  --> h24
+    return 'h$firstDigit$secondDigit';
   }
 }

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../ecma/ecma_policy.dart';
+import '../locale.dart';
+import '../options.dart';
+import '../utils.dart';
+import 'datetime_format_4x.dart';
+import 'datetime_format_options.dart';
+import 'datetime_format_stub.dart'
+    if (dart.library.js) 'datetime_format_ecma.dart';
+
+/// This is an intermediate to defer to the actual implementations of
+/// datetime formatting.
+abstract class DatetimeFormatImpl {
+  final String locale;
+
+  DatetimeFormatImpl(this.locale);
+
+  String formatImpl(DateTime datetime, DatetimeFormatOptions options);
+
+  factory DatetimeFormatImpl.build(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+    EcmaPolicy ecmaPolicy,
+  ) =>
+      buildFormatter(
+        locale,
+        localeMatcher,
+        ecmaPolicy,
+        getDatetimeFormatterECMA,
+        getDatetimeFormatter4X,
+      );
+}

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
@@ -14,7 +14,7 @@ import 'datetime_format_stub.dart'
 /// This is an intermediate to defer to the actual implementations of
 /// datetime formatting.
 abstract class DateTimeFormatImpl {
-  final String locale;
+  final Locale locale;
 
   DateTimeFormatImpl(this.locale);
 

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
@@ -13,14 +13,14 @@ import 'datetime_format_stub.dart'
 
 /// This is an intermediate to defer to the actual implementations of
 /// datetime formatting.
-abstract class DatetimeFormatImpl {
+abstract class DateTimeFormatImpl {
   final String locale;
 
-  DatetimeFormatImpl(this.locale);
+  DateTimeFormatImpl(this.locale);
 
-  String formatImpl(DateTime datetime, DatetimeFormatOptions options);
+  String formatImpl(DateTime datetime, DateTimeFormatOptions options);
 
-  factory DatetimeFormatImpl.build(
+  factory DateTimeFormatImpl.build(
     Locale locale,
     LocaleMatcher localeMatcher,
     EcmaPolicy ecmaPolicy,
@@ -29,7 +29,7 @@ abstract class DatetimeFormatImpl {
         locale,
         localeMatcher,
         ecmaPolicy,
-        getDatetimeFormatterECMA,
-        getDatetimeFormatter4X,
+        getDateTimeFormatterECMA,
+        getDateTimeFormatter4X,
       );
 }

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
@@ -9,8 +9,8 @@ typedef DayPeriod = Style;
 typedef EraRepresentation = Style;
 typedef DateStyle = TimeStyle;
 
-/// datetime formatting functionality of the browser.
-class DatetimeFormatOptions {
+/// DateTime formatting functionality of the browser.
+class DateTimeFormatOptions {
   final DateStyle? dateStyle;
   final TimeStyle? timeStyle;
   final Calendar? calendar;
@@ -32,7 +32,7 @@ class DatetimeFormatOptions {
   final FormatMatcher formatMatcher;
   final LocaleMatcher localeMatcher;
 
-  const DatetimeFormatOptions({
+  const DateTimeFormatOptions({
     this.dateStyle,
     this.timeStyle,
     this.calendar,

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../options.dart';
+
+/// datetime formatting functionality of the browser.
+class DatetimeFormatOptions {
+  final LocaleMatcher localeMatcher;
+
+  const DatetimeFormatOptions({
+    this.localeMatcher = LocaleMatcher.bestfit,
+  });
+}

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
@@ -4,11 +4,138 @@
 
 import '../options.dart';
 
+typedef WeekDayRepresentation = Style;
+typedef DayPeriod = Style;
+typedef EraRepresentation = Style;
+typedef DateStyle = TimeStyle;
+
 /// datetime formatting functionality of the browser.
 class DatetimeFormatOptions {
+  final DateStyle? dateStyle;
+  final TimeStyle? timeStyle;
+  final Calendar? calendar;
+  final DayPeriod? dayPeriod;
+  final NumberingSystem? numberingSystem;
+  final String? timeZone;
+  final bool? hour12;
+  final HourCycle? hourCycle;
+  final WeekDayRepresentation? weekday;
+  final EraRepresentation? era;
+  final TimeRepresentation? year;
+  final MonthRepresentation? month;
+  final TimeRepresentation? day;
+  final TimeRepresentation? hour;
+  final TimeRepresentation? minute;
+  final TimeRepresentation? second;
+  final int? fractionalSecondDigits;
+  final TimeZoneName? timeZoneName;
+  final FormatMatcher formatMatcher;
   final LocaleMatcher localeMatcher;
 
   const DatetimeFormatOptions({
+    this.dateStyle,
+    this.timeStyle,
+    this.calendar,
+    this.dayPeriod,
+    this.numberingSystem,
+    this.timeZone,
+    this.hour12,
+    this.hourCycle,
+    this.weekday,
+    this.era,
+    this.year,
+    this.month,
+    this.day,
+    this.hour,
+    this.minute,
+    this.second,
+    this.fractionalSecondDigits,
+    this.timeZoneName,
+    this.formatMatcher = FormatMatcher.bestfit,
     this.localeMatcher = LocaleMatcher.bestfit,
   });
+}
+
+enum TimeStyle {
+  full,
+  long,
+  medium,
+  short,
+}
+
+enum NumberingSystem {
+  arab,
+  arabext,
+  bali,
+  beng,
+  deva,
+  fullwide,
+  gujr,
+  guru,
+  hanidec,
+  khmr,
+  knda,
+  laoo,
+  latn,
+  limb,
+  mlym,
+  mong,
+  mymr,
+  orya,
+  tamldec,
+  telu,
+  thai,
+  tibt;
+}
+
+enum HourCycle {
+  h11,
+  h12,
+  h23,
+  h24;
+}
+
+enum FormatMatcher {
+  basic,
+  bestfit('best fit');
+
+  final String? _jsName;
+
+  String? get jsName => _jsName ?? name;
+
+  const FormatMatcher([this._jsName]);
+}
+
+enum MonthRepresentation {
+  numeric,
+  twodigit('2-digit'),
+  long,
+  short,
+  narrow;
+
+  String get jsName => _jsName ?? name;
+
+  final String? _jsName;
+
+  const MonthRepresentation([this._jsName]);
+}
+
+enum TimeRepresentation {
+  numeric,
+  twodigit('2-digit');
+
+  String get jsName => _jsName ?? name;
+
+  final String? _jsName;
+
+  const TimeRepresentation([this._jsName]);
+}
+
+enum TimeZoneName {
+  long,
+  short,
+  shortOffset,
+  longOffset,
+  shortGeneric,
+  longGeneric;
 }

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
@@ -4,43 +4,54 @@
 
 import '../options.dart';
 
-typedef WeekDayRepresentation = Style;
+typedef WeekDayStyle = Style;
 typedef DayPeriod = Style;
-typedef EraRepresentation = Style;
-typedef DateStyle = TimeStyle;
+typedef EraStyle = Style;
+typedef DateFormatStyle = TimeFormatStyle;
 
 /// DateTime formatting functionality of the browser.
 class DateTimeFormatOptions {
-  final DateStyle? dateStyle;
-  final TimeStyle? timeStyle;
+  /// The date formatting style.
+  final DateFormatStyle? dateFormatStyle;
+
+  /// The time formatting style.
+  final TimeFormatStyle? timeFormatStyle;
+
   final Calendar? calendar;
+
+  /// The formatting style used for day periods - only used when the [clockstyle]
+  /// parameter is true.
   final DayPeriod? dayPeriod;
   final NumberingSystem? numberingSystem;
   final String? timeZone;
-  final bool? hour12;
-  final HourCycle? hourCycle;
-  final WeekDayRepresentation? weekday;
-  final EraRepresentation? era;
-  final TimeRepresentation? year;
-  final MonthRepresentation? month;
-  final TimeRepresentation? day;
-  final TimeRepresentation? hour;
-  final TimeRepresentation? minute;
-  final TimeRepresentation? second;
+
+  /// Whether to use a 12- or 24-hour style clock.
+  final ClockStyle? clockstyle;
+  final WeekDayStyle? weekday;
+  final EraStyle? era;
+  final TimeStyle? year;
+  final MonthStyle? month;
+  final TimeStyle? day;
+  final TimeStyle? hour;
+  final TimeStyle? minute;
+  final TimeStyle? second;
+
+  /// The number of digits used to represent fractions of a second.
   final int? fractionalSecondDigits;
+
+  /// The localized representation of the time zone name.
   final TimeZoneName? timeZoneName;
   final FormatMatcher formatMatcher;
   final LocaleMatcher localeMatcher;
 
   const DateTimeFormatOptions({
-    this.dateStyle,
-    this.timeStyle,
+    this.dateFormatStyle,
+    this.timeFormatStyle,
     this.calendar,
     this.dayPeriod,
     this.numberingSystem,
     this.timeZone,
-    this.hour12,
-    this.hourCycle,
+    this.clockstyle,
     this.weekday,
     this.era,
     this.year,
@@ -56,7 +67,14 @@ class DateTimeFormatOptions {
   });
 }
 
-enum TimeStyle {
+class ClockStyle {
+  final bool is12Hour;
+  final bool? startAtZero;
+
+  const ClockStyle({required this.is12Hour, this.startAtZero});
+}
+
+enum TimeFormatStyle {
   full,
   long,
   medium,
@@ -106,7 +124,7 @@ enum FormatMatcher {
   const FormatMatcher([this._jsName]);
 }
 
-enum MonthRepresentation {
+enum MonthStyle {
   numeric,
   twodigit('2-digit'),
   long,
@@ -117,10 +135,10 @@ enum MonthRepresentation {
 
   final String? _jsName;
 
-  const MonthRepresentation([this._jsName]);
+  const MonthStyle([this._jsName]);
 }
 
-enum TimeRepresentation {
+enum TimeStyle {
   numeric,
   twodigit('2-digit');
 
@@ -128,14 +146,25 @@ enum TimeRepresentation {
 
   final String? _jsName;
 
-  const TimeRepresentation([this._jsName]);
+  const TimeStyle([this._jsName]);
 }
 
 enum TimeZoneName {
+  /// Example: `Pacific Standard Time`
   long,
+
+  /// Example: `PST`
   short,
+
+  /// Example: `GMT-8`
   shortOffset,
+
+  /// Example: `GMT-0800`
   longOffset,
+
+  /// Example: `PT`
   shortGeneric,
+
+  /// Example: `Pacific Time`
   longGeneric;
 }

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
@@ -19,8 +19,8 @@ class DateTimeFormatOptions {
 
   final Calendar? calendar;
 
-  /// The formatting style used for day periods - only used when the [clockstyle]
-  /// parameter is true.
+  /// The formatting style used for day periods - only used when the
+  /// [clockstyle] parameter is true.
   final DayPeriod? dayPeriod;
   final NumberingSystem? numberingSystem;
   final String? timeZone;

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_stub.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_stub.dart
@@ -6,7 +6,7 @@ import '../locale.dart';
 import '../options.dart';
 import 'datetime_format_impl.dart';
 
-DatetimeFormatImpl? getDatetimeFormatterECMA(
+DateTimeFormatImpl? getDateTimeFormatterECMA(
   Locale locales,
   LocaleMatcher localeMatcher,
 ) =>

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_stub.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_stub.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale.dart';
+import '../options.dart';
+import 'datetime_format_impl.dart';
+
+DatetimeFormatImpl? getDatetimeFormatterECMA(
+  Locale locales,
+  LocaleMatcher localeMatcher,
+) =>
+    throw UnimplementedError('Cannot use ECMA outside of web environments.');

--- a/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_4x.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../locale.dart';
+import '../options.dart';
 import 'display_names_impl.dart';
 import 'display_names_options.dart';
 

--- a/pkgs/intl4x/lib/src/display_names/display_names_options.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_options.dart
@@ -19,12 +19,6 @@ class DisplayNamesOptions {
   });
 }
 
-enum Style {
-  narrow,
-  short,
-  long,
-}
-
 enum DisplayType {
   calendar,
   currency,
@@ -56,31 +50,4 @@ enum DateTimeField {
   hour,
   minute,
   second,
-}
-
-enum Calendar {
-  buddhist,
-  chinese,
-  coptic,
-  dangi,
-  ethioaa,
-  ethiopic,
-  gregory,
-  hebrew,
-  indian,
-  islamic,
-  islamicUmalqura('islamic-umalqura'),
-  islamicTbla('islamic-tbla'),
-  islamicCivil('islamic-civil'),
-  islamicRgsa('islamic-rgsa'),
-  iso8601,
-  japanese,
-  persian,
-  roc;
-
-  String get jsName => _jsName ?? name;
-
-  final String? _jsName;
-
-  const Calendar([this._jsName]);
 }

--- a/pkgs/intl4x/lib/src/list_format/list_format.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../options.dart';
 import '../test_checker.dart';
 import 'list_format_impl.dart';
 import 'list_format_options.dart';
@@ -17,12 +16,7 @@ class ListFormat {
   /// ```dart
   /// format(['A', 'B', 'C']) == 'A, B, and C'
   /// ```
-  String format(
-    List<String> list, {
-    LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
-    Type type = Type.conjunction,
-    ListStyle style = ListStyle.long,
-  }) {
+  String format(List<String> list) {
     if (isInTest) {
       return '${list.join(', ')}//${_listFormatImpl.locale}';
     } else {

--- a/pkgs/intl4x/lib/src/list_format/list_format_options.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_options.dart
@@ -4,14 +4,22 @@
 
 import '../options.dart';
 
+typedef ListStyle = Style;
+
 class ListFormatOptions {
   final Type type;
+
+  /// Indicates the grouping style (for example, whether list separators and
+  /// conjunctions are included).
+  /// * long: "A, B, and C".
+  /// * short: "A, B, C".
+  /// * narrow: "A B C".
   final ListStyle style;
   final LocaleMatcher localeMatcher;
 
   const ListFormatOptions({
     this.type = Type.conjunction,
-    this.style = ListStyle.long,
+    this.style = Style.long,
     this.localeMatcher = LocaleMatcher.bestfit,
   });
 }
@@ -26,17 +34,4 @@ enum Type {
 
   /// Grouping the list items as a unit: "A, B, C".
   unit;
-}
-
-/// Indicates the grouping style (for example, whether list separators and
-/// conjunctions are included).
-enum ListStyle {
-  /// Example: "A, B, and C".
-  long,
-
-  /// Example: "A, B, C".
-  short,
-
-  /// Example: "A B C".
-  narrow;
 }

--- a/pkgs/intl4x/lib/src/list_format/list_format_options.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_options.dart
@@ -19,7 +19,7 @@ class ListFormatOptions {
 
   const ListFormatOptions({
     this.type = Type.conjunction,
-    this.style = Style.long,
+    this.style = ListStyle.long,
     this.localeMatcher = LocaleMatcher.bestfit,
   });
 }

--- a/pkgs/intl4x/lib/src/number_format/number_format_options.dart
+++ b/pkgs/intl4x/lib/src/number_format/number_format_options.dart
@@ -6,9 +6,11 @@ import 'dart:math';
 
 import '../options.dart';
 
+typedef UnitDisplay = Style;
+
 /// Number formatting functionality of the browser.
 class NumberFormatOptions {
-  final Style style;
+  final FormatStyle style;
   final String? currency;
   final CurrencyDisplay? currencyDisplay;
   final Unit? unit;
@@ -131,7 +133,7 @@ class NumberFormatOptions {
   factory NumberFormatOptions.compact({
     CompactDisplay compactDisplay = CompactDisplay.short,
     //General options
-    Style style = const DecimalStyle(),
+    FormatStyle style = const DecimalStyle(),
     LocaleMatcher localeMatcher = LocaleMatcher.bestfit,
     SignDisplay signDisplay = SignDisplay.auto,
     Grouping useGrouping = Grouping.auto,
@@ -155,7 +157,7 @@ class NumberFormatOptions {
     );
   }
 
-  static Digits? getDigits(Style style, Digits? digits) {
+  static Digits? getDigits(FormatStyle style, Digits? digits) {
     final fractionDigits = digits?.fractionDigits;
     if (fractionDigits != null) {
       final int newMin;
@@ -324,12 +326,6 @@ enum CurrencySign {
   accounting;
 }
 
-enum UnitDisplay {
-  long,
-  short,
-  narrow;
-}
-
 enum SignDisplay {
   auto,
   always,
@@ -419,20 +415,20 @@ final class EngineeringNotation extends Notation {
   String get name => 'engineering';
 }
 
-sealed class Style {
+sealed class FormatStyle {
   String get name;
 
-  const Style();
+  const FormatStyle();
 }
 
-final class DecimalStyle extends Style {
+final class DecimalStyle extends FormatStyle {
   const DecimalStyle();
 
   @override
   String get name => 'decimal';
 }
 
-final class CurrencyStyle extends Style {
+final class CurrencyStyle extends FormatStyle {
   final String currency;
   final CurrencySign sign;
   final CurrencyDisplay display;
@@ -446,13 +442,13 @@ final class CurrencyStyle extends Style {
   String get name => 'currency';
 }
 
-final class PercentStyle extends Style {
+final class PercentStyle extends FormatStyle {
   const PercentStyle();
   @override
   String get name => 'percent';
 }
 
-final class UnitStyle extends Style {
+final class UnitStyle extends FormatStyle {
   final Unit unit;
   final UnitDisplay unitDisplay;
 

--- a/pkgs/intl4x/lib/src/options.dart
+++ b/pkgs/intl4x/lib/src/options.dart
@@ -26,3 +26,36 @@ enum LocaleMatcher {
 
   const LocaleMatcher([this._jsName]);
 }
+
+enum Calendar {
+  buddhist,
+  chinese,
+  coptic,
+  dangi,
+  ethioaa,
+  ethiopic,
+  gregory,
+  hebrew,
+  indian,
+  islamic,
+  islamicUmalqura('islamic-umalqura'),
+  islamicTbla('islamic-tbla'),
+  islamicCivil('islamic-civil'),
+  islamicRgsa('islamic-rgsa'),
+  iso8601,
+  japanese,
+  persian,
+  roc;
+
+  String get jsName => _jsName ?? name;
+
+  final String? _jsName;
+
+  const Calendar([this._jsName]);
+}
+
+enum Style {
+  narrow,
+  short,
+  long,
+}

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -3,6 +3,9 @@ description: >-
   A lightweight modular library for internationalization (i18n) functionality.
 version: 0.5.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
+platforms: ## TODO: Add native platforms once ICU4X is integrated.
+  web:
+
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 
 environment:

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 
 environment:

--- a/pkgs/intl4x/test/ecma/datetime_format_test.dart
+++ b/pkgs/intl4x/test/ecma/datetime_format_test.dart
@@ -14,7 +14,7 @@ import '../utils.dart';
 void main() {
   testWithFormatting('Basic', () {
     expect(
-        Intl(defaultLocale: 'en_US')
+        Intl(locale: const Locale(language: 'en', region: 'US'))
             .datetimeFormat()
             .format(DateTime.utc(2012, 12, 20, 3, 0, 0)),
         '12/20/2012');
@@ -22,7 +22,7 @@ void main() {
 
   testWithFormatting('timezone', () {
     final date = DateTime.utc(2021, 12, 17, 3, 0, 42);
-    final intl = Intl(defaultLocale: 'en_US');
+    final intl = Intl(locale: const Locale(language: 'en', region: 'US'));
     final timeZone = 'America/Los_Angeles';
     expect(
       intl
@@ -83,7 +83,7 @@ void main() {
   testWithFormatting('day period', () {
     final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
     expect(
-        Intl(defaultLocale: 'en_GB')
+        Intl(locale: const Locale(language: 'en', region: 'GB'))
             .datetimeFormat(const DateTimeFormatOptions(
               hour: TimeRepresentation.numeric,
               hourCycle: HourCycle.h12,
@@ -94,7 +94,7 @@ void main() {
         '4 at night');
 
     expect(
-        Intl(defaultLocale: 'fr')
+        Intl(locale: const Locale(language: 'fr'))
             .datetimeFormat(const DateTimeFormatOptions(
               hour: TimeRepresentation.numeric,
               hourCycle: HourCycle.h12,
@@ -105,7 +105,7 @@ void main() {
         '4 mat.');
 
     expect(
-        Intl(defaultLocale: 'fr')
+        Intl(locale: const Locale(language: 'fr'))
             .datetimeFormat(const DateTimeFormatOptions(
               hour: TimeRepresentation.numeric,
               hourCycle: HourCycle.h12,
@@ -119,7 +119,7 @@ void main() {
   testWithFormatting('style', () {
     final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
     expect(
-        Intl(defaultLocale: 'en')
+        Intl(locale: const Locale(language: 'en'))
             .datetimeFormat(const DateTimeFormatOptions(
               timeStyle: TimeStyle.short,
               timeZone: 'UTC',
@@ -127,7 +127,7 @@ void main() {
             .format(date),
         '4:00 AM');
     expect(
-        Intl(defaultLocale: 'en')
+        Intl(locale: const Locale(language: 'en'))
             .datetimeFormat(const DateTimeFormatOptions(
               dateStyle: DateStyle.short,
               timeZone: 'UTC',
@@ -135,7 +135,7 @@ void main() {
             .format(date),
         '12/17/21');
     expect(
-        Intl(defaultLocale: 'en')
+        Intl(locale: const Locale(language: 'en'))
             .datetimeFormat(const DateTimeFormatOptions(
               timeStyle: TimeStyle.medium,
               dateStyle: DateStyle.short,

--- a/pkgs/intl4x/test/ecma/datetime_format_test.dart
+++ b/pkgs/intl4x/test/ecma/datetime_format_test.dart
@@ -5,17 +5,138 @@
 @TestOn('browser')
 library;
 
+import 'package:intl4x/datetime_format.dart';
 import 'package:intl4x/intl4x.dart';
 import 'package:test/test.dart';
 
 import '../utils.dart';
 
 void main() {
+  final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
   testWithFormatting('Basic', () {
     expect(
         Intl(defaultLocale: 'en_US')
             .datetimeFormat()
-            .format(DateTime.utc(2012, 11, 20, 3, 0, 0)),
+            .format(DateTime.utc(2012, 12, 20, 3, 0, 0)),
         '12/20/2012');
+  });
+
+  testWithFormatting('timezone', () {
+    final intl = Intl(defaultLocale: 'en_US');
+    final timeZone = 'America/Los_Angeles';
+    expect(
+      intl
+          .datetimeFormat(DatetimeFormatOptions(
+            timeZone: timeZone,
+            timeZoneName: TimeZoneName.short,
+          ))
+          .format(date),
+      '12/16/2021, PST',
+    );
+    expect(
+      intl
+          .datetimeFormat(DatetimeFormatOptions(
+            timeZone: timeZone,
+            timeZoneName: TimeZoneName.long,
+          ))
+          .format(date),
+      '12/16/2021, Pacific Standard Time',
+    );
+    expect(
+      intl
+          .datetimeFormat(DatetimeFormatOptions(
+            timeZone: timeZone,
+            timeZoneName: TimeZoneName.shortOffset,
+          ))
+          .format(date),
+      '12/16/2021, GMT-8',
+    );
+    expect(
+      intl
+          .datetimeFormat(DatetimeFormatOptions(
+            timeZone: timeZone,
+            timeZoneName: TimeZoneName.longOffset,
+          ))
+          .format(date),
+      '12/16/2021, GMT-08:00',
+    );
+    expect(
+      intl
+          .datetimeFormat(DatetimeFormatOptions(
+            timeZone: timeZone,
+            timeZoneName: TimeZoneName.shortGeneric,
+          ))
+          .format(date),
+      '12/16/2021, PT',
+    );
+    expect(
+      intl
+          .datetimeFormat(DatetimeFormatOptions(
+            timeZone: timeZone,
+            timeZoneName: TimeZoneName.longGeneric,
+          ))
+          .format(date),
+      '12/16/2021, Pacific Time',
+    );
+  });
+
+  testWithFormatting('day period', () {
+    expect(
+        Intl(defaultLocale: 'en_GB')
+            .datetimeFormat(const DatetimeFormatOptions(
+              hour: TimeRepresentation.numeric,
+              hourCycle: HourCycle.h12,
+              dayPeriod: DayPeriod.short,
+              timeZone: 'UTC',
+            ))
+            .format(date),
+        '4 at night');
+
+    expect(
+        Intl(defaultLocale: 'fr')
+            .datetimeFormat(const DatetimeFormatOptions(
+              hour: TimeRepresentation.numeric,
+              hourCycle: HourCycle.h12,
+              dayPeriod: DayPeriod.narrow,
+              timeZone: 'UTC',
+            ))
+            .format(date),
+        '4 mat.');
+
+    expect(
+        Intl(defaultLocale: 'fr')
+            .datetimeFormat(const DatetimeFormatOptions(
+              hour: TimeRepresentation.numeric,
+              hourCycle: HourCycle.h12,
+              dayPeriod: DayPeriod.long,
+              timeZone: 'UTC',
+            ))
+            .format(date),
+        '4 du matin');
+  });
+
+  testWithFormatting('style', () {
+    expect(
+        Intl(defaultLocale: 'en')
+            .datetimeFormat(const DatetimeFormatOptions(
+              timeStyle: TimeStyle.short,
+            ))
+            .format(date),
+        '5:00 AM');
+    expect(
+        Intl(defaultLocale: 'en')
+            .datetimeFormat(const DatetimeFormatOptions(
+              dateStyle: DateStyle.short,
+            ))
+            .format(date),
+        '12/17/21');
+    expect(
+        Intl(defaultLocale: 'en')
+            .datetimeFormat(const DatetimeFormatOptions(
+              timeStyle: TimeStyle.medium,
+              dateStyle: DateStyle.short,
+            ))
+            .format(date),
+        '12/17/21, 5:00:42 AM');
   });
 }

--- a/pkgs/intl4x/test/ecma/datetime_format_test.dart
+++ b/pkgs/intl4x/test/ecma/datetime_format_test.dart
@@ -85,8 +85,11 @@ void main() {
     expect(
         Intl(locale: const Locale(language: 'en', region: 'GB'))
             .datetimeFormat(const DateTimeFormatOptions(
-              hour: TimeRepresentation.numeric,
-              hourCycle: HourCycle.h12,
+              hour: TimeStyle.numeric,
+              clockstyle: ClockStyle(
+                is12Hour: true,
+                startAtZero: false,
+              ),
               dayPeriod: DayPeriod.short,
               timeZone: 'UTC',
             ))
@@ -96,8 +99,11 @@ void main() {
     expect(
         Intl(locale: const Locale(language: 'fr'))
             .datetimeFormat(const DateTimeFormatOptions(
-              hour: TimeRepresentation.numeric,
-              hourCycle: HourCycle.h12,
+              hour: TimeStyle.numeric,
+              clockstyle: ClockStyle(
+                is12Hour: true,
+                startAtZero: false,
+              ),
               dayPeriod: DayPeriod.narrow,
               timeZone: 'UTC',
             ))
@@ -107,8 +113,11 @@ void main() {
     expect(
         Intl(locale: const Locale(language: 'fr'))
             .datetimeFormat(const DateTimeFormatOptions(
-              hour: TimeRepresentation.numeric,
-              hourCycle: HourCycle.h12,
+              hour: TimeStyle.numeric,
+              clockstyle: ClockStyle(
+                is12Hour: true,
+                startAtZero: false,
+              ),
               dayPeriod: DayPeriod.long,
               timeZone: 'UTC',
             ))
@@ -121,7 +130,7 @@ void main() {
     expect(
         Intl(locale: const Locale(language: 'en'))
             .datetimeFormat(const DateTimeFormatOptions(
-              timeStyle: TimeStyle.short,
+              timeFormatStyle: TimeFormatStyle.short,
               timeZone: 'UTC',
             ))
             .format(date),
@@ -129,7 +138,7 @@ void main() {
     expect(
         Intl(locale: const Locale(language: 'en'))
             .datetimeFormat(const DateTimeFormatOptions(
-              dateStyle: DateStyle.short,
+              dateFormatStyle: DateFormatStyle.short,
               timeZone: 'UTC',
             ))
             .format(date),
@@ -137,8 +146,8 @@ void main() {
     expect(
         Intl(locale: const Locale(language: 'en'))
             .datetimeFormat(const DateTimeFormatOptions(
-              timeStyle: TimeStyle.medium,
-              dateStyle: DateStyle.short,
+              timeFormatStyle: TimeFormatStyle.medium,
+              dateFormatStyle: DateFormatStyle.short,
               timeZone: 'UTC',
             ))
             .format(date),

--- a/pkgs/intl4x/test/ecma/datetime_format_test.dart
+++ b/pkgs/intl4x/test/ecma/datetime_format_test.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:intl4x/intl4x.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWithFormatting('Basic', () {
+    expect(
+        Intl(defaultLocale: 'en_US')
+            .datetimeFormat()
+            .format(DateTime.utc(2012, 11, 20, 3, 0, 0)),
+        '12/20/2012');
+  });
+}

--- a/pkgs/intl4x/test/ecma/datetime_format_test.dart
+++ b/pkgs/intl4x/test/ecma/datetime_format_test.dart
@@ -26,7 +26,7 @@ void main() {
     final timeZone = 'America/Los_Angeles';
     expect(
       intl
-          .datetimeFormat(DatetimeFormatOptions(
+          .datetimeFormat(DateTimeFormatOptions(
             timeZone: timeZone,
             timeZoneName: TimeZoneName.short,
           ))
@@ -35,7 +35,7 @@ void main() {
     );
     expect(
       intl
-          .datetimeFormat(DatetimeFormatOptions(
+          .datetimeFormat(DateTimeFormatOptions(
             timeZone: timeZone,
             timeZoneName: TimeZoneName.long,
           ))
@@ -44,7 +44,7 @@ void main() {
     );
     expect(
       intl
-          .datetimeFormat(DatetimeFormatOptions(
+          .datetimeFormat(DateTimeFormatOptions(
             timeZone: timeZone,
             timeZoneName: TimeZoneName.shortOffset,
           ))
@@ -53,7 +53,7 @@ void main() {
     );
     expect(
       intl
-          .datetimeFormat(DatetimeFormatOptions(
+          .datetimeFormat(DateTimeFormatOptions(
             timeZone: timeZone,
             timeZoneName: TimeZoneName.longOffset,
           ))
@@ -62,7 +62,7 @@ void main() {
     );
     expect(
       intl
-          .datetimeFormat(DatetimeFormatOptions(
+          .datetimeFormat(DateTimeFormatOptions(
             timeZone: timeZone,
             timeZoneName: TimeZoneName.shortGeneric,
           ))
@@ -71,7 +71,7 @@ void main() {
     );
     expect(
       intl
-          .datetimeFormat(DatetimeFormatOptions(
+          .datetimeFormat(DateTimeFormatOptions(
             timeZone: timeZone,
             timeZoneName: TimeZoneName.longGeneric,
           ))
@@ -83,7 +83,7 @@ void main() {
   testWithFormatting('day period', () {
     expect(
         Intl(defaultLocale: 'en_GB')
-            .datetimeFormat(const DatetimeFormatOptions(
+            .datetimeFormat(const DateTimeFormatOptions(
               hour: TimeRepresentation.numeric,
               hourCycle: HourCycle.h12,
               dayPeriod: DayPeriod.short,
@@ -94,7 +94,7 @@ void main() {
 
     expect(
         Intl(defaultLocale: 'fr')
-            .datetimeFormat(const DatetimeFormatOptions(
+            .datetimeFormat(const DateTimeFormatOptions(
               hour: TimeRepresentation.numeric,
               hourCycle: HourCycle.h12,
               dayPeriod: DayPeriod.narrow,
@@ -105,7 +105,7 @@ void main() {
 
     expect(
         Intl(defaultLocale: 'fr')
-            .datetimeFormat(const DatetimeFormatOptions(
+            .datetimeFormat(const DateTimeFormatOptions(
               hour: TimeRepresentation.numeric,
               hourCycle: HourCycle.h12,
               dayPeriod: DayPeriod.long,
@@ -118,21 +118,21 @@ void main() {
   testWithFormatting('style', () {
     expect(
         Intl(defaultLocale: 'en')
-            .datetimeFormat(const DatetimeFormatOptions(
+            .datetimeFormat(const DateTimeFormatOptions(
               timeStyle: TimeStyle.short,
             ))
             .format(date),
         '5:00 AM');
     expect(
         Intl(defaultLocale: 'en')
-            .datetimeFormat(const DatetimeFormatOptions(
+            .datetimeFormat(const DateTimeFormatOptions(
               dateStyle: DateStyle.short,
             ))
             .format(date),
         '12/17/21');
     expect(
         Intl(defaultLocale: 'en')
-            .datetimeFormat(const DatetimeFormatOptions(
+            .datetimeFormat(const DateTimeFormatOptions(
               timeStyle: TimeStyle.medium,
               dateStyle: DateStyle.short,
             ))

--- a/pkgs/intl4x/test/ecma/datetime_format_test.dart
+++ b/pkgs/intl4x/test/ecma/datetime_format_test.dart
@@ -12,7 +12,6 @@ import 'package:test/test.dart';
 import '../utils.dart';
 
 void main() {
-  final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
   testWithFormatting('Basic', () {
     expect(
         Intl(defaultLocale: 'en_US')
@@ -22,6 +21,7 @@ void main() {
   });
 
   testWithFormatting('timezone', () {
+    final date = DateTime.utc(2021, 12, 17, 3, 0, 42);
     final intl = Intl(defaultLocale: 'en_US');
     final timeZone = 'America/Los_Angeles';
     expect(
@@ -81,6 +81,7 @@ void main() {
   });
 
   testWithFormatting('day period', () {
+    final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
     expect(
         Intl(defaultLocale: 'en_GB')
             .datetimeFormat(const DateTimeFormatOptions(
@@ -116,17 +117,20 @@ void main() {
   });
 
   testWithFormatting('style', () {
+    final date = DateTime.utc(2021, 12, 17, 4, 0, 42);
     expect(
         Intl(defaultLocale: 'en')
             .datetimeFormat(const DateTimeFormatOptions(
               timeStyle: TimeStyle.short,
+              timeZone: 'UTC',
             ))
             .format(date),
-        '5:00 AM');
+        '4:00 AM');
     expect(
         Intl(defaultLocale: 'en')
             .datetimeFormat(const DateTimeFormatOptions(
               dateStyle: DateStyle.short,
+              timeZone: 'UTC',
             ))
             .format(date),
         '12/17/21');
@@ -135,8 +139,9 @@ void main() {
             .datetimeFormat(const DateTimeFormatOptions(
               timeStyle: TimeStyle.medium,
               dateStyle: DateStyle.short,
+              timeZone: 'UTC',
             ))
             .format(date),
-        '12/17/21, 5:00:42 AM');
+        '12/17/21, 4:00:42 AM');
   });
 }


### PR DESCRIPTION
Add the browsers `DateTime` formatting functionality.

Note: Also has the changes from #683 to run the checks.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
