### PR TITLE
abstract number parsing

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -10,6 +10,7 @@
  * Add `EEEEE` skeleton for `DateFormat`, closing [#176](https://github.com/dart-lang/i18n/issues/176).
  * Switch to `3.0.0` SDK.
  * Fix issue [#483](https://github.com/dart-lang/i18n/issues/483) about date parsing with a `yy` skeleton.
+ * Extract `NumberParserBase` abstract class
 
 ## 0.18.1
  * Update ruble sign and update corresponding test.

--- a/pkgs/intl/lib/intl.dart
+++ b/pkgs/intl/lib/intl.dart
@@ -23,6 +23,7 @@ export 'src/intl/bidi_formatter.dart' show BidiFormatter;
 export 'src/intl/date_format.dart' show DateFormat;
 export 'src/intl/micro_money.dart' show MicroMoney;
 export 'src/intl/number_format.dart' show NumberFormat;
+export 'src/intl/number_parser_base.dart' show NumberParserBase;
 export 'src/intl/text_direction.dart' show TextDirection;
 
 /// The Intl class provides a common entry point for internationalization

--- a/pkgs/intl/lib/src/intl/number_format.dart
+++ b/pkgs/intl/lib/src/intl/number_format.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 
+import 'package:intl/intl.dart';
 import 'package:intl/number_symbols.dart';
 import 'package:intl/number_symbols_data.dart';
 import 'package:intl/src/intl_helpers.dart' as helpers;
@@ -495,7 +496,13 @@ class NumberFormat {
 
   /// Parse the number represented by the string. If it's not
   /// parseable, throws a [FormatException].
-  num parse(String text) => NumberParser(this, text).value!;
+  // TODO: use constructor tear-off syntax when dart sdk version >= 2.15
+  num parse(String text) => parseWith(text, (f, t) => NumberParser(f, t));
+
+  /// Parse the number represented by the string using the parser created by the supplied parser generator. If it's not
+  /// parseable, throws a [FormatException].
+  R parseWith<R, P extends NumberParserBase<R>>(String text, P Function(NumberFormat, String) parserGenerator) =>
+      parserGenerator(this, text).value!;
 
   /// Parse the number represented by the string. If it's not
   /// parsable, returns `null`.

--- a/pkgs/intl/lib/src/intl/number_format.dart
+++ b/pkgs/intl/lib/src/intl/number_format.dart
@@ -500,7 +500,8 @@ class NumberFormat {
 
   /// Parse the number represented by the string using the parser created by the supplied parser generator. If it's not
   /// parseable, throws a [FormatException].
-  R parseWith<R, P extends NumberParserBase<R>>(P Function(NumberFormat, String) parserGenerator, String text) =>
+  R parseWith<R, P extends NumberParserBase<R>>(
+          P Function(NumberFormat, String) parserGenerator, String text) =>
       parserGenerator(this, text).value!;
 
   /// Parse the number represented by the string. If it's not
@@ -515,7 +516,8 @@ class NumberFormat {
 
   /// Parse the number represented by the string using the parser created by the supplied parser generator. If it's not
   /// parsable, returns `null`.
-  R? tryParseWith<R, P extends NumberParserBase<R>>(P Function(NumberFormat, String) parserGenerator, String text) {
+  R? tryParseWith<R, P extends NumberParserBase<R>>(
+      P Function(NumberFormat, String) parserGenerator, String text) {
     try {
       return parseWith(parserGenerator, text);
     } on FormatException {

--- a/pkgs/intl/lib/src/intl/number_format.dart
+++ b/pkgs/intl/lib/src/intl/number_format.dart
@@ -496,7 +496,7 @@ class NumberFormat {
 
   /// Parse the number represented by the string. If it's not
   /// parseable, throws a [FormatException].
-  num parse(String text) => parseWith((f, t) => NumberParser(f, t), text);
+  num parse(String text) => parseWith(NumberParser.new, text);
 
   /// Parse the number represented by the string using the parser created by the supplied parser generator. If it's not
   /// parseable, throws a [FormatException].

--- a/pkgs/intl/lib/src/intl/number_format.dart
+++ b/pkgs/intl/lib/src/intl/number_format.dart
@@ -496,12 +496,11 @@ class NumberFormat {
 
   /// Parse the number represented by the string. If it's not
   /// parseable, throws a [FormatException].
-  // TODO: use constructor tear-off syntax when dart sdk version >= 2.15
-  num parse(String text) => parseWith(text, (f, t) => NumberParser(f, t));
+  num parse(String text) => parseWith((f, t) => NumberParser(f, t), text);
 
   /// Parse the number represented by the string using the parser created by the supplied parser generator. If it's not
   /// parseable, throws a [FormatException].
-  R parseWith<R, P extends NumberParserBase<R>>(String text, P Function(NumberFormat, String) parserGenerator) =>
+  R parseWith<R, P extends NumberParserBase<R>>(P Function(NumberFormat, String) parserGenerator, String text) =>
       parserGenerator(this, text).value!;
 
   /// Parse the number represented by the string. If it's not
@@ -509,6 +508,16 @@ class NumberFormat {
   num? tryParse(String text) {
     try {
       return parse(text);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// Parse the number represented by the string using the parser created by the supplied parser generator. If it's not
+  /// parsable, returns `null`.
+  R? tryParseWith<R, P extends NumberParserBase<R>>(P Function(NumberFormat, String) parserGenerator, String text) {
+    try {
+      return parseWith(parserGenerator, text);
     } on FormatException {
       return null;
     }

--- a/pkgs/intl/lib/src/intl/number_parser.dart
+++ b/pkgs/intl/lib/src/intl/number_parser.dart
@@ -6,7 +6,7 @@ import 'package:intl/src/intl/number_parser_base.dart';
 
 import 'number_format.dart';
 
-///  A one-time object for parsing a particular numeric string. One-time here
+/// A one-time object for parsing a particular numeric string. One-time here
 /// means an instance can only parse one string. This is implemented by
 /// transforming from a locale-specific format to one that the system can parse,
 /// then calls the system parsing methods on it.

--- a/pkgs/intl/lib/src/intl/number_parser.dart
+++ b/pkgs/intl/lib/src/intl/number_parser.dart
@@ -2,240 +2,31 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:intl/number_symbols.dart';
+import 'package:intl/src/intl/number_parser_base.dart';
 
-import 'constants.dart' as constants;
 import 'number_format.dart';
-import 'number_format_parser.dart';
-import 'string_stack.dart';
 
 ///  A one-time object for parsing a particular numeric string. One-time here
 /// means an instance can only parse one string. This is implemented by
 /// transforming from a locale-specific format to one that the system can parse,
 /// then calls the system parsing methods on it.
-class NumberParser {
-  /// The format for which we are parsing.
-  final NumberFormat format;
-
-  /// The text we are parsing.
-  final String text;
-
-  /// What we use to iterate over the input text.
-  final StringStack input;
-
-  /// The result of parsing [text] according to [format]. Automatically
-  /// populated in the constructor.
-  num? value;
-
-  /// The symbols used by our format.
-  NumberSymbols get symbols => format.symbols;
-
-  /// Where we accumulate the normalized representation of the number.
-  final StringBuffer _normalized = StringBuffer();
-
-  /// Did we see something that indicates this is, or at least might be,
-  /// a positive number.
-  bool gotPositive = false;
-
-  /// Did we see something that indicates this is, or at least might be,
-  /// a negative number.
-  bool gotNegative = false;
-
-  /// Did we see the required positive suffix at the end. Should
-  /// match [gotPositive].
-  bool gotPositiveSuffix = false;
-
-  /// Did we see the required negative suffix at the end. Should
-  /// match [gotNegative].
-  bool gotNegativeSuffix = false;
-
-  /// Should we stop parsing before hitting the end of the string.
-  bool done = false;
-
-  /// Have we already skipped over any required prefixes.
-  bool prefixesSkipped = false;
-
-  /// If the number is percent or permill, what do we divide by at the end.
-  int scale = 1;
-
-  String get _positivePrefix => format.positivePrefix;
-  String get _negativePrefix => format.negativePrefix;
-  String get _positiveSuffix => format.positiveSuffix;
-  String get _negativeSuffix => format.negativeSuffix;
-  int get _localeZero => format.localeZero;
-
+class NumberParser extends NumberParserBase<num>{
   ///  Create a new [_NumberParser] on which we can call parse().
-  NumberParser(this.format, this.text) : input = StringStack(text) {
-    scale = format.multiplier;
-    value = parse();
-  }
+  NumberParser( NumberFormat format, String text) : super(format, text);
 
-  ///  The strings we might replace with functions that return the replacement
-  /// values. They are functions because we might need to check something
-  /// in the context. Note that the ordering is important here. For example,
-  /// `symbols.PERCENT` might be " %", and we must handle that before we
-  /// look at an individual space.
-  Map<String, Function> get replacements =>
-      _replacements ??= _initializeReplacements();
+  @override
+  num fromNormalized(String normalizedText) =>
+      int.tryParse(normalizedText) ?? double.parse(normalizedText);
 
-  Map<String, Function>? _replacements;
+  @override
+  num scaled(num parsed, int scale) => parsed / scale;
 
-  Map<String, Function> _initializeReplacements() => {
-        symbols.DECIMAL_SEP: () => '.',
-        symbols.EXP_SYMBOL: () => 'E',
-        symbols.GROUP_SEP: handleSpace,
-        symbols.PERCENT: () {
-          scale = NumberFormatParser.PERCENT_SCALE;
-          return '';
-        },
-        symbols.PERMILL: () {
-          scale = NumberFormatParser.PER_MILLE_SCALE;
-          return '';
-        },
-        ' ': handleSpace,
-        '\u00a0': handleSpace,
-        '+': () => '+',
-        '-': () => '-',
-      };
+  @override
+  num nan() => 0.0 / 0.0;
 
-  void invalidFormat() =>
-      throw FormatException('Invalid number: ${input.contents}');
+  @override
+  num positiveInfinity() => 1.0 / 0.0;
 
-  /// Replace a space in the number with the normalized form. If space is not
-  /// a significant character (normally grouping) then it's just invalid. If it
-  /// is the grouping character, then it's only valid if it's followed by a
-  /// digit. e.g. '$12 345.00'
-  void handleSpace() =>
-      groupingIsNotASpaceOrElseItIsSpaceFollowedByADigit ? '' : invalidFormat();
-
-  /// Determine if a space is a valid character in the number. See
-  /// [handleSpace].
-  bool get groupingIsNotASpaceOrElseItIsSpaceFollowedByADigit {
-    if (symbols.GROUP_SEP != '\u00a0' || symbols.GROUP_SEP != ' ') return true;
-    var peeked = input.peek(symbols.GROUP_SEP.length + 1);
-    return asDigit(peeked[peeked.length - 1]) != null;
-  }
-
-  /// Turn [char] into a number representing a digit, or null if it doesn't
-  /// represent a digit in this locale.
-  int? asDigit(String char) {
-    var charCode = char.codeUnitAt(0);
-    var digitValue = charCode - _localeZero;
-    if (digitValue >= 0 && digitValue < 10) {
-      return digitValue;
-    } else {
-      return null;
-    }
-  }
-
-  /// Check to see if the input begins with either the positive or negative
-  /// prefixes. Set the [gotPositive] and [gotNegative] variables accordingly.
-  void checkPrefixes({bool skip = false}) {
-    bool checkPrefix(String prefix) =>
-        prefix.isNotEmpty && input.startsWith(prefix);
-
-    // TODO(alanknight): There's a faint possibility of a bug here where
-    // a positive prefix is followed by a negative prefix that's also a valid
-    // part of the number, but that seems very unlikely.
-    if (checkPrefix(_positivePrefix)) gotPositive = true;
-    if (checkPrefix(_negativePrefix)) gotNegative = true;
-
-    // The positive prefix might be a substring of the negative, in
-    // which case both would match.
-    if (gotPositive && gotNegative) {
-      if (_positivePrefix.length > _negativePrefix.length) {
-        gotNegative = false;
-      } else if (_negativePrefix.length > _positivePrefix.length) {
-        gotPositive = false;
-      }
-    }
-    if (skip) {
-      if (gotPositive) input.pop(_positivePrefix.length);
-      if (gotNegative) input.pop(_negativePrefix.length);
-    }
-  }
-
-  /// If the rest of our input is either the positive or negative suffix,
-  /// set [gotPositiveSuffix] or [gotNegativeSuffix] accordingly.
-  void checkSuffixes() {
-    var remainder = input.peekAll();
-    if (remainder == _positiveSuffix) gotPositiveSuffix = true;
-    if (remainder == _negativeSuffix) gotNegativeSuffix = true;
-  }
-
-  /// We've encountered a character that's not a digit. Go through our
-  /// replacement rules looking for how to handle it. If we see something
-  /// that's not a digit and doesn't have a replacement, then we're done
-  /// and the number is probably invalid.
-  void processNonDigit() {
-    // It might just be a prefix that we haven't skipped. We don't want to
-    // skip them initially because they might also be semantically meaningful,
-    // e.g. leading %. So we allow them through the loop, but only once.
-    var foundAnInterpretation = false;
-    if (input.atStart && !prefixesSkipped) {
-      prefixesSkipped = true;
-      checkPrefixes(skip: true);
-      foundAnInterpretation = true;
-    }
-
-    for (var key in replacements.keys) {
-      if (input.startsWith(key)) {
-        _normalized.write(replacements[key]!());
-        input.pop(key.length);
-        return;
-      }
-    }
-    // We haven't found either of these things, this seems invalid.
-    if (!foundAnInterpretation) {
-      done = true;
-    }
-  }
-
-  /// Parse [text] and return the resulting number. Throws [FormatException]
-  /// if we can't parse it.
-  num parse() {
-    if (text == symbols.NAN) return 0.0 / 0.0;
-    if (text == '$_positivePrefix${symbols.INFINITY}$_positiveSuffix') {
-      return 1.0 / 0.0;
-    }
-    if (text == '$_negativePrefix${symbols.INFINITY}$_negativeSuffix') {
-      return -1.0 / 0.0;
-    }
-
-    checkPrefixes();
-    var parsed = parseNumber(input);
-
-    if (gotPositive && !gotPositiveSuffix) invalidNumber();
-    if (gotNegative && !gotNegativeSuffix) invalidNumber();
-    if (!input.atEnd) invalidNumber();
-
-    return parsed;
-  }
-
-  /// The number is invalid, throw a [FormatException].
-  void invalidNumber() =>
-      throw FormatException('Invalid Number: ${input.contents}');
-
-  /// Parse the number portion of the input, i.e. not any prefixes or suffixes,
-  /// and assuming NaN and Infinity are already handled.
-  num parseNumber(StringStack input) {
-    if (gotNegative) {
-      _normalized.write('-');
-    }
-    while (!done && !input.atEnd) {
-      var digit = asDigit(input.peek());
-      if (digit != null) {
-        _normalized.writeCharCode(constants.asciiZeroCodeUnit + digit);
-        input.next();
-      } else {
-        processNonDigit();
-      }
-      checkSuffixes();
-    }
-
-    var normalizedText = _normalized.toString();
-    num? parsed = int.tryParse(normalizedText);
-    parsed ??= double.parse(normalizedText);
-    return parsed / scale;
-  }
+  @override
+  num negativeInfinity() => -1.0 / 0.0;
 }

--- a/pkgs/intl/lib/src/intl/number_parser.dart
+++ b/pkgs/intl/lib/src/intl/number_parser.dart
@@ -10,9 +10,9 @@ import 'number_format.dart';
 /// means an instance can only parse one string. This is implemented by
 /// transforming from a locale-specific format to one that the system can parse,
 /// then calls the system parsing methods on it.
-class NumberParser extends NumberParserBase<num>{
+class NumberParser extends NumberParserBase<num> {
   ///  Create a new [_NumberParser] on which we can call parse().
-  NumberParser( NumberFormat format, String text) : super(format, text);
+  NumberParser(NumberFormat format, String text) : super(format, text);
 
   @override
   num fromNormalized(String normalizedText) =>

--- a/pkgs/intl/lib/src/intl/number_parser_base.dart
+++ b/pkgs/intl/lib/src/intl/number_parser_base.dart
@@ -1,0 +1,242 @@
+import 'package:intl/number_symbols.dart';
+import 'package:intl/src/intl/string_stack.dart';
+
+import 'constants.dart' as constants;
+import 'number_format.dart';
+import 'number_format_parser.dart';
+
+abstract class NumberParserBase<R> {
+  /// The format for which we are parsing.
+  final NumberFormat format;
+
+  /// The text we are parsing.
+  final String text;
+
+  /// What we use to iterate over the input text.
+  final StringStack input;
+
+  /// The result of parsing [text] according to [format]. Automatically
+  /// populated in the constructor.
+  R? value;
+
+  /// The symbols used by our format.
+  NumberSymbols get symbols => format.symbols;
+
+  /// Where we accumulate the normalized representation of the number.
+  final StringBuffer _normalized = StringBuffer();
+
+  /// Did we see something that indicates this is, or at least might be,
+  /// a positive number.
+  bool gotPositive = false;
+
+  /// Did we see something that indicates this is, or at least might be,
+  /// a negative number.
+  bool gotNegative = false;
+
+  /// Did we see the required positive suffix at the end. Should
+  /// match [gotPositive].
+  bool gotPositiveSuffix = false;
+
+  /// Did we see the required negative suffix at the end. Should
+  /// match [gotNegative].
+  bool gotNegativeSuffix = false;
+
+  /// Should we stop parsing before hitting the end of the string.
+  bool done = false;
+
+  /// Have we already skipped over any required prefixes.
+  bool prefixesSkipped = false;
+
+  /// If the number is percent or permill, what do we divide by at the end.
+  int scale = 1;
+
+  String get _positivePrefix => format.positivePrefix;
+  String get _negativePrefix => format.negativePrefix;
+  String get _positiveSuffix => format.positiveSuffix;
+  String get _negativeSuffix => format.negativeSuffix;
+  int get _localeZero => format.localeZero;
+
+  ///  Create a new [_NumberParser] on which we can call parse().
+  NumberParserBase(this.format, this.text) : input = StringStack(text) {
+    scale = format.multiplier;
+    value = parse();
+  }
+
+  ///  The strings we might replace with functions that return the replacement
+  /// values. They are functions because we might need to check something
+  /// in the context. Note that the ordering is important here. For example,
+  /// `symbols.PERCENT` might be " %", and we must handle that before we
+  /// look at an individual space.
+  Map<String, Function> get replacements =>
+      _replacements ??= _initializeReplacements();
+
+  Map<String, Function>? _replacements;
+
+  Map<String, Function> _initializeReplacements() => {
+        symbols.DECIMAL_SEP: () => '.',
+        symbols.EXP_SYMBOL: () => 'E',
+        symbols.GROUP_SEP: handleSpace,
+        symbols.PERCENT: () {
+          scale = NumberFormatParser.PERCENT_SCALE;
+          return '';
+        },
+        symbols.PERMILL: () {
+          scale = NumberFormatParser.PER_MILLE_SCALE;
+          return '';
+        },
+        ' ': handleSpace,
+        '\u00a0': handleSpace,
+        '+': () => '+',
+        '-': () => '-',
+      };
+
+  void invalidFormat() =>
+      throw FormatException('Invalid number: ${input.contents}');
+
+  /// Replace a space in the number with the normalized form. If space is not
+  /// a significant character (normally grouping) then it's just invalid. If it
+  /// is the grouping character, then it's only valid if it's followed by a
+  /// digit. e.g. '$12 345.00'
+  void handleSpace() =>
+      groupingIsNotASpaceOrElseItIsSpaceFollowedByADigit ? '' : invalidFormat();
+
+  /// Determine if a space is a valid character in the number. See
+  /// [handleSpace].
+  bool get groupingIsNotASpaceOrElseItIsSpaceFollowedByADigit {
+    if (symbols.GROUP_SEP != '\u00a0' || symbols.GROUP_SEP != ' ') return true;
+    var peeked = input.peek(symbols.GROUP_SEP.length + 1);
+    return asDigit(peeked[peeked.length - 1]) != null;
+  }
+
+  /// Turn [char] into a number representing a digit, or null if it doesn't
+  /// represent a digit in this locale.
+  int? asDigit(String char) {
+    var charCode = char.codeUnitAt(0);
+    var digitValue = charCode - _localeZero;
+    if (digitValue >= 0 && digitValue < 10) {
+      return digitValue;
+    } else {
+      return null;
+    }
+  }
+
+  /// Check to see if the input begins with either the positive or negative
+  /// prefixes. Set the [gotPositive] and [gotNegative] variables accordingly.
+  void checkPrefixes({bool skip = false}) {
+    bool checkPrefix(String prefix) =>
+        prefix.isNotEmpty && input.startsWith(prefix);
+
+    // TODO(alanknight): There's a faint possibility of a bug here where
+    // a positive prefix is followed by a negative prefix that's also a valid
+    // part of the number, but that seems very unlikely.
+    if (checkPrefix(_positivePrefix)) gotPositive = true;
+    if (checkPrefix(_negativePrefix)) gotNegative = true;
+
+    // The positive prefix might be a substring of the negative, in
+    // which case both would match.
+    if (gotPositive && gotNegative) {
+      if (_positivePrefix.length > _negativePrefix.length) {
+        gotNegative = false;
+      } else if (_negativePrefix.length > _positivePrefix.length) {
+        gotPositive = false;
+      }
+    }
+    if (skip) {
+      if (gotPositive) input.pop(_positivePrefix.length);
+      if (gotNegative) input.pop(_negativePrefix.length);
+    }
+  }
+
+  /// If the rest of our input is either the positive or negative suffix,
+  /// set [gotPositiveSuffix] or [gotNegativeSuffix] accordingly.
+  void checkSuffixes() {
+    var remainder = input.peekAll();
+    if (remainder == _positiveSuffix) gotPositiveSuffix = true;
+    if (remainder == _negativeSuffix) gotNegativeSuffix = true;
+  }
+
+  /// We've encountered a character that's not a digit. Go through our
+  /// replacement rules looking for how to handle it. If we see something
+  /// that's not a digit and doesn't have a replacement, then we're done
+  /// and the number is probably invalid.
+  void processNonDigit() {
+    // It might just be a prefix that we haven't skipped. We don't want to
+    // skip them initially because they might also be semantically meaningful,
+    // e.g. leading %. So we allow them through the loop, but only once.
+    var foundAnInterpretation = false;
+    if (input.atStart && !prefixesSkipped) {
+      prefixesSkipped = true;
+      checkPrefixes(skip: true);
+      foundAnInterpretation = true;
+    }
+
+    for (var key in replacements.keys) {
+      if (input.startsWith(key)) {
+        _normalized.write(replacements[key]!());
+        input.pop(key.length);
+        return;
+      }
+    }
+    // We haven't found either of these things, this seems invalid.
+    if (!foundAnInterpretation) {
+      done = true;
+    }
+  }
+
+  /// Parse [text] and return the resulting number. Throws [FormatException]
+  /// if we can't parse it.
+  R parse() {
+    if (text == symbols.NAN) return nan();
+    if (text == '$_positivePrefix${symbols.INFINITY}$_positiveSuffix') {
+      return positiveInfinity();
+    }
+    if (text == '$_negativePrefix${symbols.INFINITY}$_negativeSuffix') {
+      return negativeInfinity();
+    }
+
+    checkPrefixes();
+    var parsed = parseNumber(input);
+
+    if (gotPositive && !gotPositiveSuffix) invalidNumber();
+    if (gotNegative && !gotNegativeSuffix) invalidNumber();
+    if (!input.atEnd) invalidNumber();
+
+    return parsed;
+  }
+
+  /// The number is invalid, throw a [FormatException].
+  void invalidNumber() =>
+      throw FormatException('Invalid Number: ${input.contents}');
+
+  /// Parse the number portion of the input, i.e. not any prefixes or suffixes,
+  /// and assuming NaN and Infinity are already handled.
+  R parseNumber(StringStack input) {
+    if (gotNegative) {
+      _normalized.write('-');
+    }
+    while (!done && !input.atEnd) {
+      var digit = asDigit(input.peek());
+      if (digit != null) {
+        _normalized.writeCharCode(constants.asciiZeroCodeUnit + digit);
+        input.next();
+      } else {
+        processNonDigit();
+      }
+      checkSuffixes();
+    }
+
+    var normalizedText = _normalized.toString();
+    final parsed = fromNormalized(normalizedText);
+    return scaled(parsed, scale);
+  }
+
+  R fromNormalized(String normalizedText);
+
+  R scaled(R parsed, int scale);
+
+  R nan();
+
+  R positiveInfinity();
+
+  R negativeInfinity();
+}

--- a/pkgs/intl/lib/src/intl/number_parser_base.dart
+++ b/pkgs/intl/lib/src/intl/number_parser_base.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:intl/number_symbols.dart';
 import 'package:intl/src/intl/string_stack.dart';
 


### PR DESCRIPTION
This is a step towards allowing all of the incredible number formatting work that has been done in this package to be reused for more general or custom purposes. For example, [this feature request](https://github.com/a14n/dart-decimal/issues/52) could then be fairly trivial to implement. 

Sample use case: https://github.com/anqit/dart-decimal-number-parser, happy to hear better ideas to accomplish something similar.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
