### PR TITLE
Add ECMA `PluralRules` to `package:intl4x`

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - '.github/workflows/conformance.yml'
       - 'pkgs/intl4x/**'
+  schedule:
+    - cron: '0 0 * * *' # daily
     
 jobs:
     run_all:

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.6.1-wip
+## 0.7.0
 
 - Add conformance testing workflow.
+- Add ECMA `PluralRules`.
 
 ## 0.6.0
 

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -15,10 +15,10 @@ A lightweight modular library for internationalization (i18n) functionality.
 We're actively iterating on the API for this package (please provide feedback
 via our [issue tracker](https://github.com/dart-lang/i18n/issues)).
 
-|   | Number format  | List format  | Date format  | Collation  | Display names |
-|---|:---:|:---:|:---:|:---:|:---:|
-| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| **ICU4X (web/native)**  |   |   |   |   |   | 
+|   | Number format  | List format  | Date format  | Collation  | Display names | Plural Rules |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **ECMA402 (web)** | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| **ICU4X (web/native)**  |   |   |   |   |   |   |
 
 ## Implementation and Goals
 

--- a/pkgs/intl4x/lib/intl4x.dart
+++ b/pkgs/intl4x/lib/intl4x.dart
@@ -19,6 +19,9 @@ import 'src/list_format/list_format_impl.dart';
 import 'src/list_format/list_format_options.dart';
 import 'src/locale/locale.dart';
 import 'src/number_format/number_format_impl.dart';
+import 'src/plural_rules/plural_rules.dart';
+import 'src/plural_rules/plural_rules_impl.dart';
+import 'src/plural_rules/plural_rules_options.dart';
 
 export 'src/locale/locale.dart';
 
@@ -72,6 +75,11 @@ class Intl {
       DateTimeFormat(
         options ?? const DateTimeFormatOptions(),
         DateTimeFormatImpl.build(locale, localeMatcher, ecmaPolicy),
+      );
+
+  PluralRules plural([PluralRulesOptions? options]) => PluralRules(
+        options ?? PluralRulesOptions(),
+        PluralRulesImpl.build(locale, localeMatcher, ecmaPolicy),
       );
 
   /// Construct an [Intl] instance providing the current [locale] and the

--- a/pkgs/intl4x/lib/plural_rules.dart
+++ b/pkgs/intl4x/lib/plural_rules.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/options.dart';
+export 'src/plural_rules/plural_rules.dart';
+export 'src/plural_rules/plural_rules_options.dart';

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../test_checker.dart';
+import 'plural_rules_impl.dart';
+import 'plural_rules_options.dart';
+
+class PluralRules {
+  final PluralRulesOptions _options;
+  final PluralRulesImpl _pluralRulesImpl;
+
+  const PluralRules(this._options, this._pluralRulesImpl);
+
+  /// Locale-dependant pluralization, for example in English:
+  ///
+  /// select(2) == PluralCategory.other
+  PluralCategory select(num number) {
+    if (isInTest) {
+      return PluralCategory.other;
+    } else {
+      return _pluralRulesImpl.selectImpl(number, _options);
+    }
+  }
+}
+
+enum PluralCategory {
+  zero,
+  one,
+  two,
+  few,
+  many,
+  other;
+}

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_4x.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_4x.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale/locale.dart';
+import 'plural_rules.dart';
+import 'plural_rules_impl.dart';
+import 'plural_rules_options.dart';
+
+PluralRulesImpl getPluralSelect4X(Locale locale) => PluralRules4X(locale);
+
+class PluralRules4X extends PluralRulesImpl {
+  PluralRules4X(super.locale);
+
+  @override
+  PluralCategory selectImpl(num number, PluralRulesOptions options) {
+    throw UnimplementedError('Insert diplomat bindings here');
+  }
+}

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_ecma.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_ecma.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+import '../locale/locale.dart';
+import '../options.dart';
+import 'plural_rules.dart';
+import 'plural_rules_impl.dart';
+import 'plural_rules_options.dart';
+
+PluralRulesImpl? getPluralSelectECMA(
+  Locale locale,
+  LocaleMatcher localeMatcher,
+) =>
+    _PluralRulesECMA.tryToBuild(locale, localeMatcher);
+
+@JS('Intl.PluralRules')
+class PluralRulesJS {
+  external factory PluralRulesJS([List<String> locale, Object options]);
+  external String select(num number);
+}
+
+@JS('Intl.PluralRules.supportedLocalesOf')
+external List<String> supportedLocalesOfJS(
+  List<String> listOfLocales, [
+  Object options,
+]);
+
+class _PluralRulesECMA extends PluralRulesImpl {
+  _PluralRulesECMA(super.locales);
+
+  static PluralRulesImpl? tryToBuild(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+  ) {
+    final supportedLocales = supportedLocalesOf(locale, localeMatcher);
+    return supportedLocales.isNotEmpty
+        ? _PluralRulesECMA(supportedLocales.first)
+        : null;
+  }
+
+  static List<Locale> supportedLocalesOf(
+    Locale locale,
+    LocaleMatcher localeMatcher,
+  ) {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    return List.from(supportedLocalesOfJS([locale.toLanguageTag()], o))
+        .whereType<String>()
+        .map(Locale.parse)
+        .toList();
+  }
+
+  @override
+  PluralCategory selectImpl(num number, PluralRulesOptions options) {
+    final categoryString =
+        PluralRulesJS([locale.toLanguageTag()], options.toJsOptions())
+            .select(number);
+    return PluralCategory.values
+        .firstWhere((category) => category.name == categoryString);
+  }
+}
+
+extension on PluralRulesOptions {
+  Object toJsOptions() {
+    final o = newObject<Object>();
+    setProperty(o, 'localeMatcher', localeMatcher.jsName);
+    setProperty(o, 'type', type.name);
+    setProperty(o, 'roundingMode', roundingMode.name);
+    if (digits?.roundingPriority != null) {
+      setProperty(o, 'roundingPriority', digits?.roundingPriority!.name);
+    }
+    if (digits?.roundingIncrement != null) {
+      setProperty(o, 'roundingIncrement', digits?.roundingIncrement!);
+    }
+    setProperty(o, 'minimumIntegerDigits', minimumIntegerDigits);
+    if (digits?.fractionDigits.$1 != null) {
+      setProperty(o, 'minimumFractionDigits', digits?.fractionDigits.$1);
+    }
+    if (digits?.fractionDigits.$2 != null) {
+      setProperty(o, 'maximumFractionDigits', digits?.fractionDigits.$2);
+    }
+    if (digits?.significantDigits.$1 != null) {
+      setProperty(o, 'minimumSignificantDigits', digits?.significantDigits.$1);
+    }
+    if (digits?.significantDigits.$2 != null) {
+      setProperty(o, 'maximumSignificantDigits', digits?.significantDigits.$2);
+    }
+    setProperty(o, 'trailingZeroDisplay', trailingZeroDisplay.name);
+    return o;
+  }
+}

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_impl.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_impl.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../ecma_policy.dart';
+import '../ecma/ecma_policy.dart';
+import '../locale/locale.dart';
+import '../options.dart';
+import '../utils.dart';
+import 'plural_rules.dart';
+import 'plural_rules_4x.dart';
+import 'plural_rules_options.dart';
+import 'plural_rules_stub.dart' if (dart.library.js) 'plural_rules_ecma.dart';
+
+abstract class PluralRulesImpl {
+  final Locale locale;
+
+  PluralRulesImpl(this.locale);
+
+  PluralCategory selectImpl(num number, PluralRulesOptions options);
+
+  factory PluralRulesImpl.build(
+    Locale locales,
+    LocaleMatcher localeMatcher,
+    EcmaPolicy ecmaPolicy,
+  ) =>
+      buildFormatter(
+        locales,
+        localeMatcher,
+        ecmaPolicy,
+        getPluralSelectECMA,
+        getPluralSelect4X,
+      );
+}

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_options.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_options.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../number_format.dart';
+
+typedef ListStyle = Style;
+
+class PluralRulesOptions {
+  final Type type;
+  final Digits? digits;
+  final RoundingMode roundingMode;
+  final int minimumIntegerDigits;
+  final TrailingZeroDisplay trailingZeroDisplay;
+
+  final LocaleMatcher localeMatcher;
+
+  PluralRulesOptions({
+    this.type = Type.cardinal,
+    Digits? digits,
+    this.roundingMode = RoundingMode.halfExpand,
+    this.minimumIntegerDigits = 1,
+    this.trailingZeroDisplay = TrailingZeroDisplay.auto,
+    this.localeMatcher = LocaleMatcher.bestfit,
+  }) : digits = NumberFormatOptions.getDigits(const DecimalStyle(), digits);
+
+  PluralRulesOptions copyWith({
+    Type? type,
+    Digits? digits,
+    RoundingMode? roundingMode,
+    int? minimumIntegerDigits,
+    TrailingZeroDisplay? trailingZeroDisplay,
+    LocaleMatcher? localeMatcher,
+  }) {
+    return PluralRulesOptions(
+      type: type ?? this.type,
+      digits: digits ?? this.digits,
+      roundingMode: roundingMode ?? this.roundingMode,
+      minimumIntegerDigits: minimumIntegerDigits ?? this.minimumIntegerDigits,
+      trailingZeroDisplay: trailingZeroDisplay ?? this.trailingZeroDisplay,
+      localeMatcher: localeMatcher ?? this.localeMatcher,
+    );
+  }
+}
+
+/// The number type to use.
+enum Type {
+  /// For cardinal numbers (referring to the quantity of things): One, two,
+  /// three, four, five, etc.
+  cardinal,
+
+  /// For ordinal numbers (referring to the ordering or ranking of things):
+  /// "1st", "2nd", "3rd", etc.
+  ordinal;
+}

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_stub.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_stub.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../locale/locale.dart';
+import '../options.dart';
+import 'plural_rules_impl.dart';
+
+PluralRulesImpl? getPluralSelectECMA(
+  Locale locale,
+  LocaleMatcher localeMatcher,
+) =>
+    throw UnimplementedError('Cannot use ECMA outside of web environments.');

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.6.1-wip
+version: 0.7.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 platforms: ## TODO: Add native platforms once ICU4X is integrated.
   web:

--- a/pkgs/intl4x/test/ecma/plural_rules_test.dart
+++ b/pkgs/intl4x/test/ecma/plural_rules_test.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:intl4x/intl4x.dart';
+import 'package:intl4x/plural_rules.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWithFormatting('en-US simple', () {
+    final numberFormatOptions =
+        Intl(locale: const Locale(language: 'en', region: 'US'))
+            .plural(PluralRulesOptions());
+
+    expect(numberFormatOptions.select(0), PluralCategory.other);
+    expect(numberFormatOptions.select(1), PluralCategory.one);
+    expect(numberFormatOptions.select(2), PluralCategory.other);
+    expect(numberFormatOptions.select(3), PluralCategory.other);
+  });
+
+  testWithFormatting('ar-EG simple', () {
+    final numberFormatOptions =
+        Intl(locale: const Locale(language: 'ar', region: 'EG'))
+            .plural(PluralRulesOptions());
+
+    expect(numberFormatOptions.select(0), PluralCategory.zero);
+    expect(numberFormatOptions.select(1), PluralCategory.one);
+    expect(numberFormatOptions.select(2), PluralCategory.two);
+    expect(numberFormatOptions.select(6), PluralCategory.few);
+    expect(numberFormatOptions.select(18), PluralCategory.many);
+  });
+
+  testWithFormatting('en-US ordinal', () {
+    final numberFormatOptions =
+        Intl(locale: const Locale(language: 'en', region: 'US'))
+            .plural(PluralRulesOptions(type: Type.ordinal));
+
+    expect(numberFormatOptions.select(0), PluralCategory.other);
+    expect(numberFormatOptions.select(1), PluralCategory.one);
+    expect(numberFormatOptions.select(2), PluralCategory.two);
+    expect(numberFormatOptions.select(3), PluralCategory.few);
+    expect(numberFormatOptions.select(4), PluralCategory.other);
+    expect(numberFormatOptions.select(21), PluralCategory.one);
+  });
+}

--- a/pkgs/intl4x/test/tools/conformance_config.json
+++ b/pkgs/intl4x/test/tools/conformance_config.json
@@ -9,8 +9,9 @@
             "icu_version": "icu73",
             "exec": "dart_web",
             "test_type": [
-                "coll_shift_short",
-                "number_fmt"
+                "collation_short",
+                "number_fmt",
+                "likely_subtags"
             ],
             "per_execution": 10000
         }


### PR DESCRIPTION
Add support for [Plural Rules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
