### PR TITLE
Fix error on `toString` of `Message`s.

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 0.19.0-wip
+## 0.19.0
   * Always generate null safe code, remove `null-safe` flag.
   * Add example for `he` locale.
   * MessageExtraction: add set of error codes to be ignored in analysis.
   * Upgrade dependencies on `analyzer` and `lints`.
   * Fix pubspec `repository` url.
+  * Fix error in `toString` of `Message`s.
 
 ## 0.18.1
   * Update analyzer dependency to `5.2.0`.

--- a/pkgs/intl_translation/lib/src/messages/message.dart
+++ b/pkgs/intl_translation/lib/src/messages/message.dart
@@ -47,7 +47,7 @@ import 'variable_substitution_message.dart';
 const jsonEncoder = JsonCodec();
 
 /// A default function for the [Message.expanded] method.
-String nullTransform(dynamic msg, dynamic chunk) => chunk as String;
+String nullTransform(dynamic msg, dynamic chunk) => chunk.toString();
 
 /// An abstract superclass for Intl.message/plural/gender calls in the
 /// program's source text. We

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.19.0-wip
+version: 0.19.0
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and


### PR DESCRIPTION
Fixes internal b/281585245, which happens when debugging messages.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
