### PR TITLE
Throw if the select arg is not in the list of args

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.20.0-wip
+  * Throw if the `Intl.select` `arg` is not in the list of `args`.
+
 ## 0.19.0
   * Always generate null safe code, remove `null-safe` flag.
   * Add example for `he` locale.

--- a/pkgs/intl_translation/lib/src/messages/submessages/select.dart
+++ b/pkgs/intl_translation/lib/src/messages/submessages/select.dart
@@ -108,7 +108,12 @@ class Select extends SubMessage {
   List toJson() {
     var json = [];
     json.add(dartMessageName);
-    json.add(arguments.indexOf(mainArgument));
+    var indexOfArgument = arguments.indexOf(mainArgument);
+    if (indexOfArgument == -1) {
+      throw ArgumentError(
+          'The select message $dartMessageName is being passed the argument $mainArgument, which does not occur in the list of arguments $arguments.');
+    }
+    json.add(indexOfArgument);
     var attributes = {};
     for (var arg in codeAttributeNames) {
       attributes[arg] = this[arg]!.toJson();

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.19.0
+version: 0.20.0-wip
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and


### PR DESCRIPTION
To avoid a repeat of internal b/320626018, where the name of the arg is not in the list of arguments, for example:
```dart
String messageName(int selectedSurfaces) {
  final selectedSurfacesKey = switch (selectedSurfaces) {
    0 => 'zero',
    1 => 'one',
    2 => 'two',
    _ => '',
  };

  return Intl.select(
      selectedSurfacesKey,
      {
        'zero': 'Show zero',
        'one': 'Show one',
        'two': 'Show two',
        'other': 'someteststring'
      },
      name: 'messageName',
      args: [
        selectedSurfaces,
      ],
      examples: const {'selectedSurfaces': 1},
      desc: 'Label for dropdown selection of surfaces');
}
```
Here, `selectedSurfacesKey` is not in `[selectedSurfaces]`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
