### PR TITLE
Fix clearing cache of failed locale lookup after successfully resolving locale

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.20.0-wip
+ * Fix caching of messages in CompositeMessageLookup
  * Type `numberFormatSymbols` as a `Map<String, NumberSymbols>`.
  * Type `dateTimeSymbolMap` as a `Map<String, DateSymbols>`.
  * Add example for pub.dev.

--- a/pkgs/intl/lib/message_lookup_by_library.dart
+++ b/pkgs/intl/lib/message_lookup_by_library.dart
@@ -75,8 +75,8 @@ class CompositeMessageLookup implements MessageLookup {
     if (newLocale != null) {
       availableMessages[localeName] = newLocale;
       availableMessages[canonical] = newLocale;
-      // If there was already a failed lookup for [newLocale], null the cache.
-      if (_lastLocale == newLocale) {
+      // If there was already a failed lookup for [localeName], null the cache.
+      if (_lastLocale == localeName) {
         _lastLocale = null;
         _lastLookup = null;
       }

--- a/pkgs/intl/test/message_lookup_by_library.dart
+++ b/pkgs/intl/test/message_lookup_by_library.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library message_lookup_by_library_test;
+
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Resolves message successfully after unsuccessful lookup', () {
+    final CompositeMessageLookup lookup = CompositeMessageLookup();
+    final lookupMessage =
+        lookup.lookupMessage('Hello', 'pt', 'greeting', null, null);
+    expect(lookupMessage, 'Hello');
+
+    lookup.addLocale(
+      'pt',
+      (locale) =>
+          TestMessageLookupByLibrary('pt', {'greeting': () => 'Bom dia'}),
+    );
+
+    final lookupMessage2 =
+        lookup.lookupMessage('Hello', 'pt', 'greeting', null, null);
+    expect(lookupMessage2, 'Bom dia');
+  });
+}
+
+class TestMessageLookupByLibrary extends MessageLookupByLibrary {
+  @override
+  final Map<String, dynamic> messages;
+
+  @override
+  final String localeName;
+
+  TestMessageLookupByLibrary(this.localeName, this.messages);
+}


### PR DESCRIPTION
Inside of the composite message lookup there is a clause which will never be executed that clears the cache after successfully resolving the locale.

The clause is meant to handle the case where a message is looked up before the messages have been successfully loaded as it leave the cache in a state where `_lastLocale` has been set and `_lastLookup` is null.

Since this clause is broken then any subsequent attempt to access a message from that locale will fail as the `_lookupMessageCatalog` is never called again to load the messages.

---

- [/] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

