### PR TITLE
Support WASM for `package:intl`

### DIFF
--- a/.github/workflows/intl.yml
+++ b/.github/workflows/intl.yml
@@ -30,7 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
-        id: install
         with:
           sdk: ${{matrix.sdk}}
 

--- a/.github/workflows/intl.yml
+++ b/.github/workflows/intl.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3
+        id: install
         with:
           sdk: ${{matrix.sdk}}
 
@@ -42,3 +43,7 @@ jobs:
 
       - run: dart test
         if: ${{matrix.run-tests}}
+
+      - name: Run Chrome tests - wasm
+        run: dart test --platform chrome --compiler dart2wasm
+        if: always() && steps.install.outcome == 'success' && matrix.sdk == 'dev'

--- a/.github/workflows/intl.yml
+++ b/.github/workflows/intl.yml
@@ -46,4 +46,4 @@ jobs:
 
       - name: Run Chrome tests - wasm
         run: dart test --platform chrome --compiler dart2wasm
-        if: always() && steps.install.outcome == 'success' && matrix.sdk == 'dev'
+        if: always() && matrix.sdk == 'dev'

--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -5,6 +5,9 @@
  * Add example for pub.dev.
  * Fix issues with AM/PM markers.
  * Update to CLDR v44.1.
+ * Require Dart `^3.3`
+ * Require `package:web` `^0.5.0`.
+ * Support compiling to WASM
 
 ## 0.19.0
  * Update to CLDR v44.

--- a/pkgs/intl/lib/find_locale.dart
+++ b/pkgs/intl/lib/find_locale.dart
@@ -4,6 +4,6 @@
 
 export 'src/intl_default.dart' // Stub implementation
     // Browser implementation
-    if (dart.library.html) 'intl_browser.dart'
+    if (dart.library.js_interop) 'intl_browser.dart'
     // Native implementation
     if (dart.library.io) 'intl_standalone.dart';

--- a/pkgs/intl/lib/intl_browser.dart
+++ b/pkgs/intl/lib/intl_browser.dart
@@ -9,7 +9,7 @@
 
 library intl_browser;
 
-import 'dart:html';
+import 'package:web/web.dart';
 import 'intl.dart';
 
 // TODO(alanknight): The need to do this by forcing the user to specially

--- a/pkgs/intl/lib/src/http_request_data_reader.dart
+++ b/pkgs/intl/lib/src/http_request_data_reader.dart
@@ -29,17 +29,15 @@ class HttpRequestDataReader implements LocaleDataReader {
     );
   }
 
-  Future<String> _getString(String url, Client client) {
-    return client.get(Uri.parse(url)).then((response) {
-      if ((response.statusCode >= 200 && response.statusCode < 300) ||
-          response.statusCode == 0 ||
-          response.statusCode == 304) {
-        return response.body;
-      } else {
-        throw Exception('Failed to load $url');
-      }
-    }).catchError((e) {
+  Future<String> _getString(String url, Client client) async {
+    final response = await client.get(Uri.parse(url));
+
+    if ((response.statusCode >= 200 && response.statusCode < 300) ||
+        response.statusCode == 0 ||
+        response.statusCode == 304) {
+      return response.body;
+    } else {
       throw Exception('Failed to load $url');
-    });
+    }
   }
 }

--- a/pkgs/intl/lib/src/http_request_data_reader.dart
+++ b/pkgs/intl/lib/src/http_request_data_reader.dart
@@ -8,41 +8,38 @@
 library http_request_data_reader;
 
 import 'dart:async';
-import 'dart:html';
+import 'package:http/http.dart';
 import 'intl_helpers.dart';
 
 class HttpRequestDataReader implements LocaleDataReader {
   /// The base url from which we read the data.
   String url;
+
   HttpRequestDataReader(this.url);
 
   @override
   Future<String> read(String locale) {
-    var request = HttpRequest();
-    request.timeout = 5000;
-    return _getString('$url$locale.json', request).then((r) => r.responseText!);
+    final Client client = Client();
+    return _getString('$url$locale.json', client).timeout(
+      Duration(seconds: 5),
+      onTimeout: () {
+        client.close();
+        throw TimeoutException('Timeout while reading $locale');
+      },
+    );
   }
 
-  /// Read a string with the given request. This is a stripped down copy
-  /// of HttpRequest getString, but was the simplest way I could find to
-  /// issue a request with a timeout.
-  Future<HttpRequest> _getString(String url, HttpRequest xhr) {
-    var completer = Completer<HttpRequest>();
-    xhr.open('GET', url, async: true);
-    xhr.onLoad.listen((e) {
-      // Note: file:// URIs have status of 0.
-      if ((xhr.status! >= 200 && xhr.status! < 300) ||
-          xhr.status == 0 ||
-          xhr.status == 304) {
-        completer.complete(xhr);
+  Future<String> _getString(String url, Client client) {
+    return client.get(Uri.parse(url)).then((response) {
+      if ((response.statusCode >= 200 && response.statusCode < 300) ||
+          response.statusCode == 0 ||
+          response.statusCode == 304) {
+        return response.body;
       } else {
-        completer.completeError(e);
+        throw Exception('Failed to load $url');
       }
+    }).catchError((e) {
+      throw Exception('Failed to load $url');
     });
-
-    xhr.onError.listen(completer.completeError);
-    xhr.send();
-
-    return completer.future;
   }
 }

--- a/pkgs/intl/lib/src/locale/locale_extensions.dart
+++ b/pkgs/intl/lib/src/locale/locale_extensions.dart
@@ -70,7 +70,7 @@ class LocaleExtensions {
         'RegExp/${_otherExtensionsValidValuesRE.pattern}. '
         'Entries: ${otherExtensions.entries}.');
     assert(
-        _xExtensions == null || _validXExtensionsRE.hasMatch(_xExtensions!),
+        _xExtensions == null || _validXExtensionsRE.hasMatch(_xExtensions),
         '_xExtensions must match RegExp/${_validXExtensionsRE.pattern}/ '
         'but is "$_xExtensions".');
   }

--- a/pkgs/intl/lib/src/locale/locale_implementation.dart
+++ b/pkgs/intl/lib/src/locale/locale_implementation.dart
@@ -182,7 +182,7 @@ class LocaleImplementation extends Locale {
       if (scriptCode != null) out.add(scriptCode!);
       if (countryCode != null) out.add(countryCode!);
       out.addAll(variants);
-      if (_extensions != null) out.addAll(_extensions!.subtags);
+      if (_extensions != null) out.addAll(_extensions.subtags);
       _languageTag = out.join('-');
     }
     return _languageTag!;

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -20,6 +20,5 @@ dev_dependencies:
   benchmark_harness: ^2.2.0
   ffi: ^1.0.0
   fixnum: ^1.0.0
-  js: ^0.6.3
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -11,8 +11,10 @@ environment:
 
 dependencies:
   clock: ^1.1.0
+  http: ^1.0.0
   meta: ^1.0.2
   path: ^1.8.0
+  web: ^0.5.0
 
 dev_dependencies:
   benchmark_harness: ^2.2.0

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -7,7 +7,7 @@ description: >-
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   clock: ^1.1.0

--- a/pkgs/intl/test/number_format_compact_web_test.dart
+++ b/pkgs/intl/test/number_format_compact_web_test.dart
@@ -30,8 +30,7 @@ void main() {
     expect(basic.format(1234), '\u200F1,234.00\u00A0\u200FILS');
     basic = intl.NumberFormat.currency(locale: 'he', symbol: '₪');
     expect(basic.format(1234), '\u200F1,234.00\u00A0\u200F₪');
-    expect(
-        _ecmaFormatNumber('he', 1234.toJS, style: 'currency', currency: 'ILS'),
+    expect(_ecmaFormatNumber('he', 1234, style: 'currency', currency: 'ILS'),
         '\u200F1,234.00\u00A0\u200F₪');
 
     var compact = intl.NumberFormat.compactCurrency(locale: 'he');
@@ -40,19 +39,19 @@ void main() {
     expect(compact.format(1234), '₪1.23K\u200F');
     // ECMAScript skips the RTL character for notation:'compact':
     expect(
-        _ecmaFormatNumber('he', 1234.toJS,
+        _ecmaFormatNumber('he', 1234,
             style: 'currency', currency: 'ILS', notation: 'compact'),
         '₪1.2K\u200F');
     // short/long compactDisplay doesn't change anything here:
     expect(
-        _ecmaFormatNumber('he', 1234.toJS,
+        _ecmaFormatNumber('he', 1234,
             style: 'currency',
             currency: 'ILS',
             notation: 'compact',
             compactDisplay: 'short'),
         '₪1.2K\u200F');
     expect(
-        _ecmaFormatNumber('he', 1234.toJS,
+        _ecmaFormatNumber('he', 1234,
             style: 'currency',
             currency: 'ILS',
             notation: 'compact',
@@ -64,7 +63,7 @@ void main() {
   });
 }
 
-String _ecmaFormatNumber(String locale, JSNumber number,
+String _ecmaFormatNumber(String locale, num number,
     {String? style,
     String? currency,
     String? notation,
@@ -84,9 +83,10 @@ String _ecmaFormatNumber(String locale, JSNumber number,
       maximumSignificantDigits.toJS,
     );
   }
-  if (useGrouping != null)
+  if (useGrouping != null) {
     options.setProperty('useGrouping'.toJS, useGrouping.toJS);
-  return number.toLocaleString(locale, options);
+  }
+  return number.toJS.toLocaleString(locale, options);
 }
 
 var _unsupportedChromeLocales = [
@@ -130,7 +130,7 @@ void _validateShort(String locale, List<List<String>> expected) {
       expect(
           _ecmaFormatNumber(
             locale,
-            number.toJS,
+            number,
             notation: 'compact',
             useGrouping: false,
           ),
@@ -150,7 +150,7 @@ void _validateLong(String locale, List<List<String>> expected) {
       expect(
           _ecmaFormatNumber(
             locale,
-            number.toJS,
+            number,
             notation: 'compact',
             compactDisplay: 'long',
             useGrouping: false,

--- a/pkgs/intl/test/number_format_compact_web_test.dart
+++ b/pkgs/intl/test/number_format_compact_web_test.dart
@@ -17,6 +17,10 @@ import 'package:test/test.dart';
 import 'compact_number_test_data.dart' as testdata;
 import 'more_compact_number_test_data.dart' as more_testdata;
 
+extension on JSNumber {
+  external String toLocaleString(String locale, [JSObject? options]);
+}
+
 void main() {
   testdata.compactNumberTestData.forEach(_validate);
   more_testdata.cldr35CompactNumTests.forEach(_validateMore);
@@ -26,7 +30,8 @@ void main() {
     expect(basic.format(1234), '\u200F1,234.00\u00A0\u200FILS');
     basic = intl.NumberFormat.currency(locale: 'he', symbol: '₪');
     expect(basic.format(1234), '\u200F1,234.00\u00A0\u200F₪');
-    expect(_ecmaFormatNumber('he', 1234.toJS, style: 'currency', currency: 'ILS'),
+    expect(
+        _ecmaFormatNumber('he', 1234.toJS, style: 'currency', currency: 'ILS'),
         '\u200F1,234.00\u00A0\u200F₪');
 
     var compact = intl.NumberFormat.compactCurrency(locale: 'he');
@@ -59,37 +64,6 @@ void main() {
   });
 }
 
-@JSExport()
-class FakeEcmaNumberFormat {
-  String? notation;
-  String? compactDisplay;
-  String? style;
-  String? currency;
-  int? minimumIntegerDigits;
-  int? maximumIntegerDigits;
-  int? minimumSignificantDigits;
-  int? maximumSignificantDigits;
-  int? minimumFractionDigits;
-  int? maximumFractionDigits;
-  int? minimumExponentDigits;
-  bool? useGrouping;
-}
-
-extension type EcmaFormatNumber(JSObject _) implements JSObject {
-  external String? notation;
-  external String? compactDisplay;
-  external String? style;
-  external String? currency;
-  external int? minimumIntegerDigits;
-  external int? maximumIntegerDigits;
-  external int? minimumSignificantDigits;
-  external int? maximumSignificantDigits;
-  external int? minimumFractionDigits;
-  external int? maximumFractionDigits;
-  external int? minimumExponentDigits;
-  external bool? useGrouping;
-}
-
 String _ecmaFormatNumber(String locale, JSNumber number,
     {String? style,
     String? currency,
@@ -97,19 +71,22 @@ String _ecmaFormatNumber(String locale, JSNumber number,
     String? compactDisplay,
     int? maximumSignificantDigits,
     bool? useGrouping}) {
-  var fakeOptions = FakeEcmaNumberFormat();
-  var options = createJSInteropWrapper<FakeEcmaNumberFormat>(fakeOptions) as EcmaFormatNumber;
-  if (notation != null) options.notation = notation;
+  final options = JSObject();
+  if (notation != null) options.setProperty('notation'.toJS, notation.toJS);
   if (compactDisplay != null) {
-    options.compactDisplay = compactDisplay;
+    options.setProperty('compactDisplay'.toJS, compactDisplay.toJS);
   }
-  if (style != null) options.style = style;
-  if (currency != null) options.currency = currency;
+  if (style != null) options.setProperty('style'.toJS, style.toJS);
+  if (currency != null) options.setProperty('currency'.toJS, currency.toJS);
   if (maximumSignificantDigits != null) {
-    options.maximumSignificantDigits = maximumSignificantDigits;
+    options.setProperty(
+      'maximumSignificantDigits'.toJS,
+      maximumSignificantDigits.toJS,
+    );
   }
-  if (useGrouping != null) options.useGrouping = useGrouping;
-  return number.callMethod('toLocaleString', [locale, options]);
+  if (useGrouping != null)
+    options.setProperty('useGrouping'.toJS, useGrouping.toJS);
+  return number.toLocaleString(locale, options);
 }
 
 var _unsupportedChromeLocales = [
@@ -184,40 +161,60 @@ void _validateLong(String locale, List<List<String>> expected) {
 }
 
 void _validateMore(more_testdata.CompactRoundingTestCase t) {
-  var fakeOptions = FakeEcmaNumberFormat();
-  var options = createJSInteropWrapper<FakeEcmaNumberFormat>(fakeOptions) as EcmaFormatNumber;
-  options.notation = 'compact';
+  final options = JSObject();
+  options.setProperty('notation'.toJS, 'compact'.toJS);
   if (t.maximumIntegerDigits != null) {
-    options.maximumIntegerDigits = t.maximumIntegerDigits;
+    options.setProperty(
+      'maximumIntegerDigits'.toJS,
+      t.maximumIntegerDigits!.toJS,
+    );
   }
 
   if (t.minimumIntegerDigits != null) {
-    options.minimumIntegerDigits = t.minimumIntegerDigits;
+    options.setProperty(
+      'minimumIntegerDigits'.toJS,
+      t.minimumIntegerDigits!.toJS,
+    );
   }
 
   if (t.maximumFractionDigits != null) {
-    options.maximumFractionDigits = t.maximumFractionDigits;
+    options.setProperty(
+      'maximumFractionDigits'.toJS,
+      t.maximumFractionDigits!.toJS,
+    );
   }
 
   if (t.minimumFractionDigits != null) {
-    options.minimumFractionDigits = t.minimumFractionDigits;
+    options.setProperty(
+      'minimumFractionDigits'.toJS,
+      t.minimumFractionDigits!.toJS,
+    );
   }
 
   if (t.minimumExponentDigits != null) {
-    options.minimumExponentDigits = t.minimumExponentDigits;
+    options.setProperty(
+      'minimumExponentDigits'.toJS,
+      t.minimumExponentDigits!.toJS,
+    );
   }
 
   if (t.maximumSignificantDigits != null) {
-    options.maximumSignificantDigits = t.maximumSignificantDigits;
+    options.setProperty(
+      'maximumSignificantDigits'.toJS,
+      t.maximumSignificantDigits!.toJS,
+    );
   }
 
   if (t.minimumSignificantDigits != null) {
-    options.minimumSignificantDigits = t.minimumSignificantDigits;
+    options.setProperty(
+      'minimumSignificantDigits'.toJS,
+      t.minimumSignificantDigits!.toJS,
+    );
   }
 
   test(t.toString(), () {
     expect(
-      t.number.callMethod('toLocaleString', ['en-US', options]),
+      t.number.toJS.toLocaleString('en-US', options),
       t.expected,
     );
   });

--- a/pkgs/intl/test/number_format_compact_web_test.dart
+++ b/pkgs/intl/test/number_format_compact_web_test.dart
@@ -75,7 +75,7 @@ class FakeEcmaNumberFormat {
   bool? useGrouping;
 }
 
-extension type EcmaFormatNumbe(JSObject _) implements JSObject {
+extension type EcmaFormatNumber(JSObject _) implements JSObject {
   external String? notation;
   external String? compactDisplay;
   external String? style;
@@ -97,7 +97,8 @@ String _ecmaFormatNumber(String locale, JSNumber number,
     String? compactDisplay,
     int? maximumSignificantDigits,
     bool? useGrouping}) {
-  var options = FakeEcmaNumberFormat();
+  var fakeOptions = FakeEcmaNumberFormat();
+  var options = createJSInteropWrapper<FakeEcmaNumberFormat>(fakeOptions) as EcmaFormatNumber;
   if (notation != null) options.notation = notation;
   if (compactDisplay != null) {
     options.compactDisplay = compactDisplay;
@@ -183,7 +184,8 @@ void _validateLong(String locale, List<List<String>> expected) {
 }
 
 void _validateMore(more_testdata.CompactRoundingTestCase t) {
-  var options = FakeEcmaNumberFormat();
+  var fakeOptions = FakeEcmaNumberFormat();
+  var options = createJSInteropWrapper<FakeEcmaNumberFormat>(fakeOptions) as EcmaFormatNumber;
   options.notation = 'compact';
   if (t.maximumIntegerDigits != null) {
     options.maximumIntegerDigits = t.maximumIntegerDigits;

--- a/pkgs/intl/test/number_format_compact_web_test.dart
+++ b/pkgs/intl/test/number_format_compact_web_test.dart
@@ -71,20 +71,17 @@ String _ecmaFormatNumber(String locale, num number,
     int? maximumSignificantDigits,
     bool? useGrouping}) {
   final options = JSObject();
-  if (notation != null) options.setProperty('notation'.toJS, notation.toJS);
+  if (notation != null) options['notation'] = notation.toJS;
   if (compactDisplay != null) {
-    options.setProperty('compactDisplay'.toJS, compactDisplay.toJS);
+    options['compactDisplay'] = compactDisplay.toJS;
   }
-  if (style != null) options.setProperty('style'.toJS, style.toJS);
-  if (currency != null) options.setProperty('currency'.toJS, currency.toJS);
+  if (style != null) options['style'] = style.toJS;
+  if (currency != null) options['currency'] = currency.toJS;
   if (maximumSignificantDigits != null) {
-    options.setProperty(
-      'maximumSignificantDigits'.toJS,
-      maximumSignificantDigits.toJS,
-    );
+    options['maximumSignificantDigits'] = maximumSignificantDigits.toJS;
   }
   if (useGrouping != null) {
-    options.setProperty('useGrouping'.toJS, useGrouping.toJS);
+    options['useGrouping'] = useGrouping.toJS;
   }
   return number.toJS.toLocaleString(locale, options);
 }
@@ -162,54 +159,33 @@ void _validateLong(String locale, List<List<String>> expected) {
 
 void _validateMore(more_testdata.CompactRoundingTestCase t) {
   final options = JSObject();
-  options.setProperty('notation'.toJS, 'compact'.toJS);
+  options['notation'] = 'compact'.toJS;
   if (t.maximumIntegerDigits != null) {
-    options.setProperty(
-      'maximumIntegerDigits'.toJS,
-      t.maximumIntegerDigits!.toJS,
-    );
+    options['maximumIntegerDigits'] = t.maximumIntegerDigits!.toJS;
   }
 
   if (t.minimumIntegerDigits != null) {
-    options.setProperty(
-      'minimumIntegerDigits'.toJS,
-      t.minimumIntegerDigits!.toJS,
-    );
+    options['minimumIntegerDigits'] = t.minimumIntegerDigits!.toJS;
   }
 
   if (t.maximumFractionDigits != null) {
-    options.setProperty(
-      'maximumFractionDigits'.toJS,
-      t.maximumFractionDigits!.toJS,
-    );
+    options['maximumFractionDigits'] = t.maximumFractionDigits!.toJS;
   }
 
   if (t.minimumFractionDigits != null) {
-    options.setProperty(
-      'minimumFractionDigits'.toJS,
-      t.minimumFractionDigits!.toJS,
-    );
+    options['minimumFractionDigits'] = t.minimumFractionDigits!.toJS;
   }
 
   if (t.minimumExponentDigits != null) {
-    options.setProperty(
-      'minimumExponentDigits'.toJS,
-      t.minimumExponentDigits!.toJS,
-    );
+    options['minimumExponentDigits'] = t.minimumExponentDigits!.toJS;
   }
 
   if (t.maximumSignificantDigits != null) {
-    options.setProperty(
-      'maximumSignificantDigits'.toJS,
-      t.maximumSignificantDigits!.toJS,
-    );
+    options['maximumSignificantDigits'] = t.maximumSignificantDigits!.toJS;
   }
 
   if (t.minimumSignificantDigits != null) {
-    options.setProperty(
-      'minimumSignificantDigits'.toJS,
-      t.minimumSignificantDigits!.toJS,
-    );
+    options['minimumSignificantDigits'] = t.minimumSignificantDigits!.toJS;
   }
 
   test(t.toString(), () {


### PR DESCRIPTION
Adds support for compiling to WASM engine.

Fixes #801 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
