### PR TITLE
Revert "Support WASM for `package:intl`"

### DIFF
--- a/.github/workflows/intl.yml
+++ b/.github/workflows/intl.yml
@@ -42,7 +42,3 @@ jobs:
 
       - run: dart test
         if: ${{matrix.run-tests}}
-
-      - name: Run Chrome tests - wasm
-        run: dart test --platform chrome --compiler dart2wasm
-        if: always() && matrix.sdk == 'dev'

--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -5,9 +5,6 @@
  * Add example for pub.dev.
  * Fix issues with AM/PM markers.
  * Update to CLDR v44.1.
- * Require Dart `^3.3`
- * Require `package:web` `^0.5.0`.
- * Support compiling to WASM
 
 ## 0.19.0
  * Update to CLDR v44.

--- a/pkgs/intl/lib/find_locale.dart
+++ b/pkgs/intl/lib/find_locale.dart
@@ -4,6 +4,6 @@
 
 export 'src/intl_default.dart' // Stub implementation
     // Browser implementation
-    if (dart.library.js_interop) 'intl_browser.dart'
+    if (dart.library.html) 'intl_browser.dart'
     // Native implementation
     if (dart.library.io) 'intl_standalone.dart';

--- a/pkgs/intl/lib/intl_browser.dart
+++ b/pkgs/intl/lib/intl_browser.dart
@@ -9,7 +9,7 @@
 
 library intl_browser;
 
-import 'package:web/web.dart';
+import 'dart:html';
 import 'intl.dart';
 
 // TODO(alanknight): The need to do this by forcing the user to specially

--- a/pkgs/intl/lib/src/locale/locale_extensions.dart
+++ b/pkgs/intl/lib/src/locale/locale_extensions.dart
@@ -70,7 +70,7 @@ class LocaleExtensions {
         'RegExp/${_otherExtensionsValidValuesRE.pattern}. '
         'Entries: ${otherExtensions.entries}.');
     assert(
-        _xExtensions == null || _validXExtensionsRE.hasMatch(_xExtensions),
+        _xExtensions == null || _validXExtensionsRE.hasMatch(_xExtensions!),
         '_xExtensions must match RegExp/${_validXExtensionsRE.pattern}/ '
         'but is "$_xExtensions".');
   }

--- a/pkgs/intl/lib/src/locale/locale_implementation.dart
+++ b/pkgs/intl/lib/src/locale/locale_implementation.dart
@@ -182,7 +182,7 @@ class LocaleImplementation extends Locale {
       if (scriptCode != null) out.add(scriptCode!);
       if (countryCode != null) out.add(countryCode!);
       out.addAll(variants);
-      if (_extensions != null) out.addAll(_extensions.subtags);
+      if (_extensions != null) out.addAll(_extensions!.subtags);
       _languageTag = out.join('-');
     }
     return _languageTag!;

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -7,18 +7,17 @@ description: >-
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.0.0
 
 dependencies:
   clock: ^1.1.0
-  http: ^1.0.0
   meta: ^1.0.2
   path: ^1.8.0
-  web: ^0.5.0
 
 dev_dependencies:
   benchmark_harness: ^2.2.0
   ffi: ^1.0.0
   fixnum: ^1.0.0
+  js: ^0.6.3
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0

--- a/pkgs/intl/test/number_format_compact_web_test.dart
+++ b/pkgs/intl/test/number_format_compact_web_test.dart
@@ -9,17 +9,12 @@
 // consistency when the bug is fixed. Also fix documentation and perhaps
 // merge tests: these tests currently also touch non-compact currency
 // formatting.
-import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 import 'package:intl/intl.dart' as intl;
+import 'package:js/js_util.dart' as js;
 import 'package:test/test.dart';
 
 import 'compact_number_test_data.dart' as testdata;
 import 'more_compact_number_test_data.dart' as more_testdata;
-
-extension on JSNumber {
-  external String toLocaleString(String locale, [JSObject? options]);
-}
 
 void main() {
   testdata.compactNumberTestData.forEach(_validate);
@@ -70,20 +65,19 @@ String _ecmaFormatNumber(String locale, num number,
     String? compactDisplay,
     int? maximumSignificantDigits,
     bool? useGrouping}) {
-  final options = JSObject();
-  if (notation != null) options['notation'] = notation.toJS;
+  var options = js.newObject();
+  if (notation != null) js.setProperty(options, 'notation', notation);
   if (compactDisplay != null) {
-    options['compactDisplay'] = compactDisplay.toJS;
+    js.setProperty(options, 'compactDisplay', compactDisplay);
   }
-  if (style != null) options['style'] = style.toJS;
-  if (currency != null) options['currency'] = currency.toJS;
+  if (style != null) js.setProperty(options, 'style', style);
+  if (currency != null) js.setProperty(options, 'currency', currency);
   if (maximumSignificantDigits != null) {
-    options['maximumSignificantDigits'] = maximumSignificantDigits.toJS;
+    js.setProperty(
+        options, 'maximumSignificantDigits', maximumSignificantDigits);
   }
-  if (useGrouping != null) {
-    options['useGrouping'] = useGrouping.toJS;
-  }
-  return number.toJS.toLocaleString(locale, options);
+  if (useGrouping != null) js.setProperty(options, 'useGrouping', useGrouping);
+  return js.callMethod(number, 'toLocaleString', [locale, options]);
 }
 
 var _unsupportedChromeLocales = [
@@ -158,40 +152,40 @@ void _validateLong(String locale, List<List<String>> expected) {
 }
 
 void _validateMore(more_testdata.CompactRoundingTestCase t) {
-  final options = JSObject();
-  options['notation'] = 'compact'.toJS;
+  var options = js.newObject();
+  js.setProperty(options, 'notation', 'compact');
   if (t.maximumIntegerDigits != null) {
-    options['maximumIntegerDigits'] = t.maximumIntegerDigits!.toJS;
+    js.setProperty(options, 'maximumIntegerDigits', t.maximumIntegerDigits);
   }
 
   if (t.minimumIntegerDigits != null) {
-    options['minimumIntegerDigits'] = t.minimumIntegerDigits!.toJS;
+    js.setProperty(options, 'minimumIntegerDigits', t.minimumIntegerDigits);
   }
 
   if (t.maximumFractionDigits != null) {
-    options['maximumFractionDigits'] = t.maximumFractionDigits!.toJS;
+    js.setProperty(options, 'maximumFractionDigits', t.maximumFractionDigits);
   }
 
   if (t.minimumFractionDigits != null) {
-    options['minimumFractionDigits'] = t.minimumFractionDigits!.toJS;
+    js.setProperty(options, 'minimumFractionDigits', t.minimumFractionDigits);
   }
 
   if (t.minimumExponentDigits != null) {
-    options['minimumExponentDigits'] = t.minimumExponentDigits!.toJS;
+    js.setProperty(options, 'minimumExponentDigits', t.minimumExponentDigits);
   }
 
   if (t.maximumSignificantDigits != null) {
-    options['maximumSignificantDigits'] = t.maximumSignificantDigits!.toJS;
+    js.setProperty(
+        options, 'maximumSignificantDigits', t.maximumSignificantDigits);
   }
 
   if (t.minimumSignificantDigits != null) {
-    options['minimumSignificantDigits'] = t.minimumSignificantDigits!.toJS;
+    js.setProperty(
+        options, 'minimumSignificantDigits', t.minimumSignificantDigits);
   }
 
   test(t.toString(), () {
-    expect(
-      t.number.toJS.toLocaleString('en-US', options),
-      t.expected,
-    );
+    expect(js.callMethod(t.number, 'toLocaleString', ['en-US', options]),
+        t.expected);
   });
 }


### PR DESCRIPTION
Reverts dart-lang/i18n#802, as this was merged here and not by copybara, causing breakages in g3.