### PR TITLE
Prepare intl_translation for release support intl 0.19

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.20.0-wip
   * Throw if the `Intl.select` `arg` is not in the list of `args`.
+  * Require `package:intl` `^0.19.0`.
+  * Require Dart 3.
 
 ## 0.19.0
   * Always generate null safe code, remove `null-safe` flag.

--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.20.0-wip
+## 0.20.0
   * Throw if the `Intl.select` `arg` is not in the list of `args`.
   * Require `package:intl` `^0.19.0`.
-  * Require Dart 3.
+  * Require Dart 3 or later.
 
 ## 0.19.0
   * Always generate null safe code, remove `null-safe` flag.

--- a/pkgs/intl_translation/bin/extract_to_arb.dart
+++ b/pkgs/intl_translation/bin/extract_to_arb.dart
@@ -6,7 +6,7 @@
 /// This script uses the extract_messages.dart library to find the Intl.message
 /// calls in the target dart files and produces ARB format output. See
 /// https://code.google.com/p/arb/wiki/ApplicationResourceBundleSpecification
-library extract_to_arb;
+library;
 
 import 'dart:convert';
 import 'dart:io';

--- a/pkgs/intl_translation/bin/generate_from_arb.dart
+++ b/pkgs/intl_translation/bin/generate_from_arb.dart
@@ -15,8 +15,7 @@
 /// "messages_<locale>.dart" containing messages for a particular locale
 /// and a main import file named "messages_all.dart" which has imports all of
 /// them and provides an initializeMessages function.
-
-library generate_from_arb;
+library;
 
 import 'dart:convert';
 import 'dart:io';

--- a/pkgs/intl_translation/lib/extract_messages.dart
+++ b/pkgs/intl_translation/lib/extract_messages.dart
@@ -17,7 +17,7 @@
 /// Note that this does not understand how to follow part directives, so it
 /// has to explicitly be given all the files that it needs. A typical use case
 /// is to run it on all .dart files in a directory.
-library extract_messages;
+library;
 
 import 'dart:io';
 

--- a/pkgs/intl_translation/lib/generate_localized.dart
+++ b/pkgs/intl_translation/lib/generate_localized.dart
@@ -9,7 +9,7 @@
 ///
 /// An example of usage can be found
 /// in test/message_extract/generate_from_json.dart
-library generate_localized;
+library;
 
 import 'dart:convert';
 import 'dart:io';

--- a/pkgs/intl_translation/lib/src/message_parser.dart
+++ b/pkgs/intl_translation/lib/src/message_parser.dart
@@ -4,7 +4,7 @@
 
 /// Contains a parser for ICU format plural/gender/select format for localized
 /// messages. See extract_to_arb.dart and make_hardcoded_translation.dart.
-library message_parser;
+library;
 
 import 'messages/composite_message.dart';
 import 'messages/literal_string_message.dart';

--- a/pkgs/intl_translation/lib/src/messages/message.dart
+++ b/pkgs/intl_translation/lib/src/messages/message.dart
@@ -29,8 +29,7 @@
 /// This representation isn't used at runtime. Rather, we read some format
 /// from a translation file, parse it into these objects, and they are then
 /// used to generate the code representation above.
-
-library intl_message;
+library;
 
 import 'dart:convert';
 

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.20.0-wip
+version: 0.20.0
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and
@@ -7,14 +7,14 @@ description: >-
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl_translation
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   analyzer: ^6.3.0
   args: ^2.0.0
-  dart_style: ^2.0.0
-  intl: ^0.18.0
-  path: ^1.0.0
+  dart_style: ^2.2.0
+  intl: ^0.19.0
+  path: ^1.8.0
 
 dev_dependencies:
   lints: ^3.0.0

--- a/pkgs/intl_translation/test/data_directory.dart
+++ b/pkgs/intl_translation/test/data_directory.dart
@@ -9,7 +9,7 @@
 ///    test/ or a sub-directory.
 ///   - running in root of this package, which is where the editor and bots will
 ///   run things by default
-library data_directory;
+library;
 
 import 'dart:io';
 

--- a/pkgs/intl_translation/test/message_extraction/embedded_plural_text_after.dart
+++ b/pkgs/intl_translation/test/message_extraction/embedded_plural_text_after.dart
@@ -4,7 +4,7 @@
 
 /// A test library that should fail because there is a plural with text
 /// following the plural expression.
-library embedded_plural_text_after;
+library;
 
 import 'package:intl/intl.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/embedded_plural_text_after_test.dart
+++ b/pkgs/intl_translation/test/message_extraction/embedded_plural_text_after_test.dart
@@ -3,8 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(seconds: 180))
-
-library embedded_plural_text_after_test;
+library;
 
 import 'package:test/test.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/embedded_plural_text_before.dart
+++ b/pkgs/intl_translation/test/message_extraction/embedded_plural_text_before.dart
@@ -4,7 +4,7 @@
 
 /// A test library that should fail because there is a plural with text
 /// before the plural expression.
-library embedded_plural_text_before;
+library;
 
 import 'package:intl/intl.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/embedded_plural_text_before_test.dart
+++ b/pkgs/intl_translation/test/message_extraction/embedded_plural_text_before_test.dart
@@ -3,8 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(seconds: 180))
-
-library embedded_plural_text_before_test;
+library;
 
 import 'package:test/test.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/failed_extraction_test.dart
+++ b/pkgs/intl_translation/test/message_extraction/failed_extraction_test.dart
@@ -3,8 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(seconds: 180))
-
-library failed_extraction_test;
+library;
 
 import 'dart:io';
 

--- a/pkgs/intl_translation/test/message_extraction/foo_messages_all.dart
+++ b/pkgs/intl_translation/test/message_extraction/foo_messages_all.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library keep_the_static_analysis_from_complaining;
-
 Future<bool> initializeMessages(_) =>
     throw UnimplementedError('This entire file is only here to make the static'
         ' analysis happy. It will be generated during actual tests.');

--- a/pkgs/intl_translation/test/message_extraction/message_extraction_no_deferred_test.dart
+++ b/pkgs/intl_translation/test/message_extraction/message_extraction_no_deferred_test.dart
@@ -6,7 +6,7 @@
 
 /// A test for message extraction and code generation not using deferred
 /// loading for the generated code.
-library message_extraction_no_deferred_test;
+library;
 
 import 'package:test/test.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/message_extraction_test.dart
+++ b/pkgs/intl_translation/test/message_extraction/message_extraction_test.dart
@@ -3,8 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(seconds: 180))
-
-library message_extraction_test;
+library;
 
 import 'dart:convert';
 import 'dart:io';

--- a/pkgs/intl_translation/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
+++ b/pkgs/intl_translation/test/message_extraction/mock_flutter/foo_messages_de_DE.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library keep_the_static_analysis_from_complaining;
-
 class MessageLookup {
   String get messages => throw UnimplementedError(
       'This entire file is only here to make the static'

--- a/pkgs/intl_translation/test/message_extraction/mock_flutter/foo_messages_fr.dart
+++ b/pkgs/intl_translation/test/message_extraction/mock_flutter/foo_messages_fr.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library keep_the_static_analysis_from_complaining;
-
 class MessageLookup {
   String get messages => throw UnimplementedError(
       'This entire file is only here to make the static'

--- a/pkgs/intl_translation/test/message_extraction/print_to_list.dart
+++ b/pkgs/intl_translation/test/message_extraction/print_to_list.dart
@@ -4,8 +4,7 @@
 
 /// This provides a way for a test to print to an internal list so the
 /// results can be verified rather than writing to and reading a file.
-
-library print_to_list.dart;
+library;
 
 List<String> lines = [];
 

--- a/pkgs/intl_translation/test/message_extraction/really_fail_extraction_test.dart
+++ b/pkgs/intl_translation/test/message_extraction/really_fail_extraction_test.dart
@@ -3,8 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Timeout(Duration(seconds: 180))
-
-library really_fail_extraction_test;
+library;
 
 import 'package:test/test.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/run_and_verify.dart
+++ b/pkgs/intl_translation/test/message_extraction/run_and_verify.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library verify_and_run;
-
 import 'dart:convert';
 import 'dart:io';
 

--- a/pkgs/intl_translation/test/message_extraction/sample_with_messages.dart
+++ b/pkgs/intl_translation/test/message_extraction/sample_with_messages.dart
@@ -5,7 +5,7 @@
 /// This is a program with various [Intl.message] messages. It just prints
 /// all of them, and is used for testing of message extraction, translation,
 /// and code generation.
-library sample;
+library;
 
 import 'package:intl/intl.dart';
 

--- a/pkgs/intl_translation/test/message_extraction/verify_messages.dart
+++ b/pkgs/intl_translation/test/message_extraction/verify_messages.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library verify_messages;
-
 import 'print_to_list.dart';
 
 void verifyResult() {


### PR DESCRIPTION
- Update constraint on `package:intl` from `^0.18.0` to `^0.19.0`.
   This enables support for Flutter 3.22 which pins `package:intl:0.19.0`.
- Update SDK constraint to `^3.0.0`.
- Take advantage of unnamed libraries.