### PR TITLE
Add `topics` to package intl `pubspec.yaml`

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -8,6 +8,7 @@
  * Require Dart `^3.3`
  * Require `package:web` `^0.5.0`.
  * Support compiling to WASM
+ * Add topics to `pubspec.yaml`
 
 ## 0.19.0
  * Update to CLDR v44.

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -6,6 +6,10 @@ description: >-
   internationalization issues.
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl
 
+topics:
+ - i18n
+ - intl
+
 environment:
   sdk: ^3.3.0
 


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

```topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics