### PR TITLE
Add `topics` to package intl_translation `pubspec.yaml`

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.20.1 - wip
+  * Add topics to `pubspec.yaml`
+
 ## 0.20.0
   * Throw if the `Intl.select` `arg` is not in the list of `args`.
   * Support `package:intl` `0.19.0`.

--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.20.1 - wip
+## 0.20.1-wip
   * Add topics to `pubspec.yaml`
 
 ## 0.20.0

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.20.0
+version: 0.20.1
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -6,6 +6,10 @@ description: >-
   other internationalization issues.
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl_translation
 
+topics:
+- i18n
+- intl
+
 environment:
   sdk: ^3.0.0
 

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.20.1
+version: 0.20.1-wip
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

```topics:
 - my-topic
 - some-other-topic
```

See also: https://dart.dev/tools/pub/pubspec#topics