### PR TITLE
Change Future<void> to void for initializeDateFormatting method in da…

### DIFF
--- a/pkgs/intl/lib/date_symbol_data_local.dart
+++ b/pkgs/intl/lib/date_symbol_data_local.dart
@@ -27,10 +27,9 @@ import "src/date_format_internal.dart";
 /// formatting methods are called. It sets up the lookup for date
 /// symbols. Both the [locale] and [ignored] parameter are ignored, as
 /// the data for all locales is directly available.
-Future<void> initializeDateFormatting([String? locale, String? ignored]) {
+void initializeDateFormatting([String? locale, String? ignored]) {
   initializeDateSymbols(dateTimeSymbolMap);
   initializeDatePatterns(dateTimePatternMap);
-  return new Future.value();
 }
 
 /// Returns a Map from locale names to the DateSymbols instance for


### PR DESCRIPTION
**Change Future<void> to void for initializeDateFormatting method in date_symbol_data_local.dart.**

Inside this method, exclusively synchronous functions are called and there is no need to return the future

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
