### PR TITLE
added central kordi to the rtl language regex

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -9,6 +9,7 @@
  * Require `package:web` `^0.5.0`.
  * Support compiling to WASM.
  * Update to and account for `package:lints` `^4.0.0`.
+ * rtl Detection fix in `bidi.dart` for Kordi Sorani "ckb".
 
 ## 0.19.0
  * Update to CLDR v44.

--- a/pkgs/intl/lib/src/intl/bidi.dart
+++ b/pkgs/intl/lib/src/intl/bidi.dart
@@ -109,7 +109,7 @@ class Bidi {
   }
 
   static final _rtlLocaleRegex = RegExp(
-      r'^(ar|dv|he|iw|fa|nqo|ps|sd|ug|ur|yi|.*[-_]'
+      r'^(ar|ckb|dv|he|iw|fa|nqo|ps|sd|ug|ur|yi|.*[-_]'
       r'(Arab|Hebr|Thaa|Nkoo|Tfng))(?!.*[-_](Latn|Cyrl)($|-|_))'
       r'($|-|_)',
       caseSensitive: false);

--- a/pkgs/intl/test/bidi_utils_test.dart
+++ b/pkgs/intl/test/bidi_utils_test.dart
@@ -31,6 +31,7 @@ void main() {
     expect(Bidi.isRtlLanguage('az-Arab'), isTrue);
     expect(Bidi.isRtlLanguage('az-ARAB-IR'), isTrue);
     expect(Bidi.isRtlLanguage('az_arab_IR'), isTrue);
+    expect(Bidi.isRtlLanguage('ckb'), isTrue);
     Intl.withLocale('en_US', () {
       expect(Bidi.isRtlLanguage(), isFalse);
     });


### PR DESCRIPTION
i have noticed the issue numbered #827 and modified the regex in the isRtl in bidi to handle central Kordi .
it should work now , I hope it is an ideal solution 