### PR TITLE
Update SDK constraint for `pub publish`

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,7 +19,7 @@ jobs:
       steps:
         - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
           with:
-            sdk: stable
+            sdk: dev
 
         - uses: actions/checkout@7739b9ba2efcda9dde65ad1e3c2dbe65b41dfba7
                 

--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: pkgs/intl4x
     strategy:
       matrix:
-        sdk: [stable, dev] # {pkgs.versions}
+        sdk: [dev]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - sdk: dev

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,7 @@ jobs:
     if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     with:
+      sdk: dev
       write-comments: false
       checkout_submodules: true
       ignore-packages: "submodules"

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Copy files instead of symlinking, for easier upgrading.
 - Get binaries from Github and check their hashes.
+- Upgrade minimum SDK to `3.6.0`.
 
 ## 0.9.1
 

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Copy files instead of symlinking, for easier upgrading.
 - Get binaries from Github and check their hashes.
-- Upgrade minimum SDK to `3.6.0`.
+- Upgrade minimum SDK to `3.6.0-0`.
 
 ## 0.9.1
 

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 0.10.0
+
+- Upgrade minimum SDK to `3.6.0-0`.
+
 ## 0.9.2
 
 - Copy files instead of symlinking, for easier upgrading.
 - Get binaries from Github and check their hashes.
-- Upgrade minimum SDK to `3.6.0-0`.
 
 ## 0.9.1
 

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - i18n
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.6.0-0 <4.0.0"
 
 dependencies:
   crypto: ^3.0.3

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.9.2
+version: 0.10.0
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 platforms:
   web:

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -14,7 +14,7 @@ topics:
   - i18n
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
   crypto: ^3.0.3


### PR DESCRIPTION
This is the minimum SDK version for build hooks to be allowed now apparently.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
