### PR TITLE
Pass a language version to DartFormatter().

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.20.1-wip
   * Add topics to `pubspec.yaml`
+  * Update to `dart_style `2.3.7`. `bin/make_examples_const.dart` and
+    `rewrite_intl_messages.dart` will now look for a surrounding
+    `.dart_tool/package_config.json` file to infer the language version of the
+    files updated by the script.
 
 ## 0.20.0
   * Throw if the `Intl.select` `arg` is not in the list of `args`.
@@ -30,7 +34,7 @@
   * Remove petit_parser dependency.
   * Address analyzer deprecations, see [#168](https://github.com/dart-lang/intl_translation/issues/168).
   * Migrate to null safety.
-  
+
 ## 0.17.10+1
   * Generate code that passes analysis with `implicit-casts: false`.
   * Allow use of `MessageExtraction` and `MessageGeneration` without `File`.

--- a/pkgs/intl_translation/bin/make_examples_const.dart
+++ b/pkgs/intl_translation/bin/make_examples_const.dart
@@ -10,10 +10,11 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:intl_translation/src/language_version.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 import 'package:intl_translation/src/messages/main_message.dart';
 
-void main(List<String> args) {
+Future<void> main(List<String> args) async {
   var parser = ArgParser();
   var rest = parser.parse(args).rest;
   if (rest.isEmpty) {
@@ -24,7 +25,6 @@ void main(List<String> args) {
     exit(0);
   }
 
-  var formatter = DartFormatter();
   for (var inputFile in rest) {
     var outputFile = inputFile;
     var file = File(inputFile);
@@ -35,6 +35,11 @@ void main(List<String> args) {
     } else {
       print('Writing new source to $outputFile');
       var out = File(outputFile);
+
+      var languageVersion = (await findPackageLanguageVersion(file)) ??
+          DartFormatter.latestLanguageVersion;
+      var formatter = DartFormatter(languageVersion: languageVersion);
+
       out.writeAsStringSync(formatter.format(newSource));
     }
   }

--- a/pkgs/intl_translation/bin/rewrite_intl_messages.dart
+++ b/pkgs/intl_translation/bin/rewrite_intl_messages.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:intl_translation/src/language_version.dart';
 import 'package:intl_translation/src/message_rewriter.dart';
 
 String? outputFileOption = 'transformed_output.dart';
@@ -23,7 +24,7 @@ String? outputFileOption = 'transformed_output.dart';
 bool useStringSubstitution = true;
 bool replace = false;
 
-void main(List<String> args) {
+Future<void> main(List<String> args) async {
   var parser = ArgParser();
   parser.addOption('output',
       defaultsTo: 'transformed_output.dart',
@@ -55,7 +56,6 @@ void main(List<String> args) {
     exit(0);
   }
 
-  var formatter = DartFormatter();
   for (var inputFile in rest) {
     var outputFile = replace ? inputFile : outputFileOption;
     var file = File(inputFile);
@@ -67,6 +67,11 @@ void main(List<String> args) {
     } else {
       print('Writing new source to $outputFile');
       var out = File(outputFile!);
+
+      var languageVersion = (await findPackageLanguageVersion(file)) ??
+          DartFormatter.latestLanguageVersion;
+      var formatter = DartFormatter(languageVersion: languageVersion);
+
       out.writeAsStringSync(formatter.format(newSource));
     }
   }

--- a/pkgs/intl_translation/lib/src/language_version.dart
+++ b/pkgs/intl_translation/lib/src/language_version.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+/// Looks for a package surrounding [file] and, if found, returns the default
+/// language version specified by that package.
+Future<Version?> findPackageLanguageVersion(File file) async {
+  try {
+    var config = await findPackageConfig(file.parent);
+    if (config?.packageOf(file.absolute.uri)?.languageVersion
+        case var languageVersion?) {
+      return Version(languageVersion.major, languageVersion.minor, 0);
+    }
+  } catch (error) {
+    // If we fail to find or read a config, just silently do nothing and
+    // default to the latest language version.
+  }
+
+  return null;
+}

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -18,7 +18,9 @@ dependencies:
   args: ^2.0.0
   dart_style: ^2.0.0
   intl: '>=0.18.0 <0.20.0'
+  package_config: ^2.1.0
   path: ^1.0.0
+  pub_semver: '>=1.4.4 <3.0.0'
 
 dev_dependencies:
   lints: ^4.0.0


### PR DESCRIPTION
We're in [the process of](https://github.com/dart-lang/dart_style/issues/1403) moving dart_style to [a new formatting style](https://github.com/dart-lang/dart_style/issues/1253). That involves making the formatter [aware of the language version of what it's formatting](https://github.com/dart-lang/dart_style/issues/1402).

That in turn means that the library API now lets you pass in a language version. In dart_style 2.3.7 [you can pass in a language version but the parameter is optional](https://pub.dev/documentation/dart_style/latest/dart_style/DartFormatter/DartFormatter.html). In the forthcoming 3.0.0 release, that parameter will become mandatory.

This updates the two calls to `DartFormatter()` in intl_translation/bin to pass in a language version. It attempts to look for a surrounding package_config.json file and uses the language version from that (which is what other Dart tools do). If that files, it just defaults to using the latest language version that the formatter supports.
