### PR TITLE
rev package:intl to 0.20.1 in prep for publishing

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.20.1-wip
+## 0.20.1
  * Upgrade `package:web` dependency constraint to `1.1.0`, fixes issue
    [#916](https://github.com/dart-lang/i18n/issues/916).
  * Update to CLDR v46.

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,10 +1,11 @@
 name: intl
-version: 0.20.1-wip
+version: 0.20.1
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other
   internationalization issues.
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl
+issue_tracker: https://github.com/dart-lang/i18n/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aintl
 
 topics:
  - i18n


### PR DESCRIPTION
- rev package:intl to 0.20.1 in prep for publishing

This will let people resolve package:intl `0.20.x` w/ package:web `1.0`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
