### PR TITLE
remove package:http from package:intl

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.20.2-wip
+ * Remove the dependency on `package:http`.
+
 ## 0.20.1
  * Upgrade `package:web` dependency constraint to `1.1.0`, fixes issue
    [#916](https://github.com/dart-lang/i18n/issues/916).

--- a/pkgs/intl/lib/date_symbol_data_http_request.dart
+++ b/pkgs/intl/lib/date_symbol_data_http_request.dart
@@ -20,7 +20,7 @@ export 'src/data/dates/locale_list.dart';
 /// The [url] parameter should end with a "/". For example,
 ///   "http://localhost:8000/dates/"
 Future<void> initializeDateFormatting(String locale, String url) {
-  //Initialize symbols
+  // Initialize symbols
   var symbolReader = HttpRequestDataReader('${url}symbols/');
   LazyLocaleData symbolsInitializer() => LazyLocaleData(
         symbolReader,
@@ -29,7 +29,7 @@ Future<void> initializeDateFormatting(String locale, String url) {
       );
   initializeDateSymbols(symbolsInitializer);
 
-  //Initialize patterns
+  // Initialize patterns
   var patternsReader = HttpRequestDataReader('${url}patterns/');
   LazyLocaleData patternsInitializer() => LazyLocaleData(
         patternsReader,
@@ -43,7 +43,7 @@ Future<void> initializeDateFormatting(String locale, String url) {
     availableLocalesForDateFormatting.contains,
   )!;
 
-  //Initialize locale for both symbols and patterns
+  /// Initialize locale for both symbols and patterns.
   Future<List<void>> initLocale(
     LazyLocaleData symbols,
     LazyLocaleData patterns,

--- a/pkgs/intl/lib/src/http_request_data_reader.dart
+++ b/pkgs/intl/lib/src/http_request_data_reader.dart
@@ -2,39 +2,40 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// This contains a reader that accesses data using the HttpRequest
-/// facility, and thus works only in the web browser.
+/// This contains a reader that accesses data using the HttpRequest facility,
+/// and thus works only in the web browser.
 library;
 
 import 'dart:async';
-import 'package:http/http.dart';
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
 import 'intl_helpers.dart';
 
 class HttpRequestDataReader implements LocaleDataReader {
   /// The base url from which we read the data.
-  String url;
+  final String url;
 
   HttpRequestDataReader(this.url);
 
   @override
   Future<String> read(String locale) {
-    final Client client = Client();
-    return _getString('$url$locale.json', client).timeout(
+    return _getString('$url$locale.json').timeout(
       Duration(seconds: 5),
       onTimeout: () {
-        client.close();
         throw TimeoutException('Timeout while reading $locale');
       },
     );
   }
 
-  Future<String> _getString(String url, Client client) async {
-    final response = await client.get(Uri.parse(url));
+  Future<String> _getString(String url) async {
+    final response = await window.fetch(url.toJS).toDart;
 
-    if ((response.statusCode >= 200 && response.statusCode < 300) ||
-        response.statusCode == 0 ||
-        response.statusCode == 304) {
-      return response.body;
+    if ((response.status >= 200 && response.status < 300) ||
+        response.status == 0 ||
+        response.status == 304) {
+      return (await response.text().toDart).toDart;
     } else {
       throw Exception('Failed to load $url');
     }

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl
-version: 0.20.1
+version: 0.20.2-wip
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other
@@ -16,8 +16,7 @@ environment:
 
 dependencies:
   clock: ^1.1.0
-  http: ^1.0.0
-  meta: ^1.0.2
+  meta: ^1.3.0
   path: ^1.8.0
   web: ^1.1.0
 
@@ -26,4 +25,4 @@ dev_dependencies:
   ffi: ^2.1.3
   fixnum: ^1.0.0
   lints: ^5.0.0
-  test: ^1.16.0
+  test: ^1.16.6


### PR DESCRIPTION
- remove package:http from package:intl
- run `dart pub run downgrade --tighten`

This uses `fetch` from package:web directly instead of using package:http. This works in this case - the library in question (lib/src/http_request_data_reader.dart) is only ever called from the browser.

This PR moves the package to a `-wip` version; we'll likely want to follow this up with a PR looking to in-line uses of package:web (assuming that that's a tractable amount of code).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
