### PR TITLE
no longer leak StringStack from our API

### DIFF
--- a/pkgs/intl/lib/src/intl/date_builder.dart
+++ b/pkgs/intl/lib/src/intl/date_builder.dart
@@ -6,8 +6,8 @@ import 'package:clock/clock.dart';
 
 import 'date_computation.dart' as date_computation;
 
-/// A class for holding onto the data for a date so that it can be built
-/// up incrementally.
+/// A class for holding onto the data for a date so that it can be built up
+/// incrementally.
 class DateBuilder {
   // Default the date values to the EPOCH so that there's a valid date
   // in case the format doesn't set them.


### PR DESCRIPTION
- remove places where we were leaking `StringStack` from our API

This might technically be a breaking change for our users, but I assume that in practice nobody was relying on the visibility here. This leak was reported on my previous PR from the health check:

<img width="834" alt="Screenshot 2024-12-19 at 12 39 54 PM" src="https://github.com/user-attachments/assets/a7ce9d71-c73f-4727-9f75-ebfa8724c637" />

I was not able to find where we were leaking `DateBuilder` from.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
