### PR TITLE
remove the dependency on package:web

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.20.2-wip
+ * Remove the dependency on `package:http`.
+
 ## 0.20.1
  * Upgrade `package:web` dependency constraint to `1.1.0`, fixes issue
    [#916](https://github.com/dart-lang/i18n/issues/916).

--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.20.2-wip
+## 0.20.2
  * Remove the dependency on `package:http`.
+ * Remove the dependency on `package:web`.
 
 ## 0.20.1
  * Upgrade `package:web` dependency constraint to `1.1.0`, fixes issue

--- a/pkgs/intl/lib/date_symbol_data_http_request.dart
+++ b/pkgs/intl/lib/date_symbol_data_http_request.dart
@@ -20,7 +20,7 @@ export 'src/data/dates/locale_list.dart';
 /// The [url] parameter should end with a "/". For example,
 ///   "http://localhost:8000/dates/"
 Future<void> initializeDateFormatting(String locale, String url) {
-  //Initialize symbols
+  // Initialize symbols
   var symbolReader = HttpRequestDataReader('${url}symbols/');
   LazyLocaleData symbolsInitializer() => LazyLocaleData(
         symbolReader,
@@ -29,7 +29,7 @@ Future<void> initializeDateFormatting(String locale, String url) {
       );
   initializeDateSymbols(symbolsInitializer);
 
-  //Initialize patterns
+  // Initialize patterns
   var patternsReader = HttpRequestDataReader('${url}patterns/');
   LazyLocaleData patternsInitializer() => LazyLocaleData(
         patternsReader,
@@ -43,7 +43,7 @@ Future<void> initializeDateFormatting(String locale, String url) {
     availableLocalesForDateFormatting.contains,
   )!;
 
-  //Initialize locale for both symbols and patterns
+  /// Initialize locale for both symbols and patterns.
   Future<List<void>> initLocale(
     LazyLocaleData symbols,
     LazyLocaleData patterns,

--- a/pkgs/intl/lib/intl_browser.dart
+++ b/pkgs/intl/lib/intl_browser.dart
@@ -4,21 +4,22 @@
 
 /// This provides facilities for Internationalization that are only available
 /// when running in the web browser. You should import only one of this or
-/// intl_standalone.dart. Right now the only thing provided here is the
-/// ability to find the default locale from the browser.
+/// intl_standalone.dart. Right now the only thing provided here is the ability
+/// to find the default locale from the browser.
 library;
 
-import 'package:web/web.dart';
 import 'intl.dart';
+import 'src/web.dart';
 
-// TODO(alanknight): The need to do this by forcing the user to specially
-// import a particular library is a horrible hack, only done because there
-// seems to be no graceful way to do this at all. Either mirror access on
-// dart2js or the ability to do spawnUri in the browser would be promising
-// as ways to get rid of this requirement.
-/// Find the system locale, accessed as window.navigator.language, and
-/// set it as the default for internationalization operations in the
-/// [Intl.systemLocale] variable.
+// TODO(alanknight): The need to do this by forcing the user to specially import
+// a particular library is a horrible hack, only done because there seems to be
+// no graceful way to do this at all. Either mirror access on dart2js or the
+// ability to do spawnUri in the browser would be promising as ways to get rid
+// of this requirement.
+
+/// Find the system locale, accessed as window.navigator.language, and set it as
+/// the default for internationalization operations in the [Intl.systemLocale]
+/// variable.
 Future<String> findSystemLocale() {
   Intl.systemLocale = Intl.canonicalizedLocale(window.navigator.language);
   return Future.value(Intl.systemLocale);

--- a/pkgs/intl/lib/intl_standalone.dart
+++ b/pkgs/intl/lib/intl_standalone.dart
@@ -9,6 +9,7 @@
 library;
 
 import 'dart:io';
+
 import 'intl.dart';
 
 // TODO(alanknight): The need to do this by forcing the user to specially

--- a/pkgs/intl/lib/message_format.dart
+++ b/pkgs/intl/lib/message_format.dart
@@ -10,6 +10,7 @@
 library;
 
 import 'dart:collection';
+
 import 'intl.dart';
 
 /// **MessageFormat grammar:**

--- a/pkgs/intl/lib/src/file_data_reader.dart
+++ b/pkgs/intl/lib/src/file_data_reader.dart
@@ -9,6 +9,7 @@ library;
 import 'dart:io';
 
 import 'package:path/path.dart';
+
 import 'intl_helpers.dart';
 
 class FileDataReader implements LocaleDataReader {

--- a/pkgs/intl/lib/src/http_request_data_reader.dart
+++ b/pkgs/intl/lib/src/http_request_data_reader.dart
@@ -2,39 +2,40 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// This contains a reader that accesses data using the HttpRequest
-/// facility, and thus works only in the web browser.
+/// This contains a reader that accesses data using the HttpRequest facility,
+/// and thus works only in the web browser.
 library;
 
 import 'dart:async';
-import 'package:http/http.dart';
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
 import 'intl_helpers.dart';
 
 class HttpRequestDataReader implements LocaleDataReader {
   /// The base url from which we read the data.
-  String url;
+  final String url;
 
   HttpRequestDataReader(this.url);
 
   @override
   Future<String> read(String locale) {
-    final Client client = Client();
-    return _getString('$url$locale.json', client).timeout(
+    return _getString('$url$locale.json').timeout(
       Duration(seconds: 5),
       onTimeout: () {
-        client.close();
         throw TimeoutException('Timeout while reading $locale');
       },
     );
   }
 
-  Future<String> _getString(String url, Client client) async {
-    final response = await client.get(Uri.parse(url));
+  Future<String> _getString(String url) async {
+    final response = await window.fetch(url.toJS).toDart;
 
-    if ((response.statusCode >= 200 && response.statusCode < 300) ||
-        response.statusCode == 0 ||
-        response.statusCode == 304) {
-      return response.body;
+    if ((response.status >= 200 && response.status < 300) ||
+        response.status == 0 ||
+        response.status == 304) {
+      return (await response.text().toDart).toDart;
     } else {
       throw Exception('Failed to load $url');
     }

--- a/pkgs/intl/lib/src/http_request_data_reader.dart
+++ b/pkgs/intl/lib/src/http_request_data_reader.dart
@@ -9,9 +9,8 @@ library;
 import 'dart:async';
 import 'dart:js_interop';
 
-import 'package:web/web.dart';
-
 import 'intl_helpers.dart';
+import 'web.dart';
 
 class HttpRequestDataReader implements LocaleDataReader {
   /// The base url from which we read the data.

--- a/pkgs/intl/lib/src/intl/number_format_parser.dart
+++ b/pkgs/intl/lib/src/intl/number_format_parser.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:math';
 
 import 'package:intl/number_symbols.dart';

--- a/pkgs/intl/lib/src/lazy_locale_data.dart
+++ b/pkgs/intl/lib/src/lazy_locale_data.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'dart:convert';
+
 import 'intl_helpers.dart';
 
 /// This implements the very basic map-type operations which are used

--- a/pkgs/intl/lib/src/web.dart
+++ b/pkgs/intl/lib/src/web.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Note: the contents of this file have been inlined from package:web/web.dart.
+// We may periodically want to re-sync this, and / or look there when necessary
+// to expose additional API.
+
+import 'dart:js_interop';
+
+@JS()
+external Window get window;
+
+extension type Window._(JSObject _) implements JSObject {
+  external Navigator get navigator;
+
+  external JSPromise<Response> fetch(
+    JSAny /*RequestInfo*/ input, [
+    JSObject /*RequestInit*/ init,
+  ]);
+}
+
+extension type Navigator._(JSObject _) implements JSObject {
+  external String get language;
+}
+
+extension type Response._(JSObject _) implements JSObject {
+  external int get status;
+  external JSPromise<JSString> text();
+}

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl
-version: 0.20.2-wip
+version: 0.20.2
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other
@@ -18,7 +18,6 @@ dependencies:
   clock: ^1.1.0
   meta: ^1.3.0
   path: ^1.8.0
-  web: ^1.1.0
 
 dev_dependencies:
   benchmark_harness: ^2.2.0

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl
-version: 0.20.1
+version: 0.20.2-wip
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other
@@ -16,8 +16,7 @@ environment:
 
 dependencies:
   clock: ^1.1.0
-  http: ^1.0.0
-  meta: ^1.0.2
+  meta: ^1.3.0
   path: ^1.8.0
   web: ^1.1.0
 
@@ -26,4 +25,4 @@ dev_dependencies:
   ffi: ^2.1.3
   fixnum: ^1.0.0
   lints: ^5.0.0
-  test: ^1.16.0
+  test: ^1.16.6


### PR DESCRIPTION
- remove the dependency on package:web

This removes the dep on package:web by in-lining the pieces we use. This is built on top of https://github.com/dart-lang/i18n/pull/928 - I'd review and land that first; I can update this after.

And - while this analyzes correctly and the tests run - I have not tried running this in a browser. We'd probably want to do that before a publish.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
