### PR TITLE
Update Turkish Lira (TRY) symbol to ₺ (U+20BA)

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Next Release]
+ * Updated the Turkish Lira (TRY) currency symbol in `simpleCurrencySymbols`  
+   from "TL" to "₺" (U+20BA). This ensures accuracy and alignment with the  
+   official symbol introduced in 2012.
+
 ## 0.20.2
  * Remove the dependency on `package:http`.
  * Remove the dependency on `package:web`.

--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Next Release]
+## 0.20.3-wip
  * Updated the Turkish Lira (TRY) currency symbol in `simpleCurrencySymbols`  
    from "TL" to "₺" (U+20BA). This ensures accuracy and alignment with the  
    official symbol introduced in 2012.

--- a/pkgs/intl/lib/src/intl/constants.dart
+++ b/pkgs/intl/lib/src/intl/constants.dart
@@ -91,7 +91,7 @@ final Map<String, String> simpleCurrencySymbols = {
   'RON': 'RON',
   'BGN': 'lev',
   'SZL': 'SZL',
-  'TRY': 'TL',
+  'TRY': '\u20BA',
   'LTL': 'Lt',
   'LSL': 'LSL',
   'AZN': 'man.',

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl
-version: 0.20.2
+version: 0.20.3-wip
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other


### PR DESCRIPTION
This PR updates the Turkish Lira (TRY) currency symbol in the simpleCurrencySymbols map from "TL" to "₺" (Unicode: U+20BA). This change aligns with the official symbol for Turkish Lira introduced in 2012.

No functional changes are introduced, as this update only modifies the symbol representation. The change ensures consistency and accuracy in displaying the currency.

Why
The current symbol "TL" is outdated. The Unicode character "₺" is the official and globally recognized symbol for Turkish Lira.

Relevant Issues
N/A – This is a minor update to align with modern standards.

Checklist
 I’ve reviewed the contributor guide and applied the relevant portions to this PR.
 I’ve verified that the change works as expected and doesn’t introduce any regressions.
No additional tests were added since this is a minor symbol update for Turkish Lira (TRY). If a dedicated test is required, I am happy to add one