### PR TITLE
feat(intl): ignore script subtags when canonicalizing locale strings

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -2,6 +2,9 @@
  * Updated the Turkish Lira (TRY) currency symbol in `simpleCurrencySymbols`  
    from "TL" to "₺" (U+20BA). This ensures accuracy and alignment with the  
    official symbol introduced in 2012.
+ * Fix parsing of locale strings containing script codes in `verifiedLocale`.
+   For example, `zh-Hans-CN` would have been previously parsed as `zh`, but is
+   now parsed as `zh_CN`.
 
 ## 0.20.2
  * Remove the dependency on `package:http`.

--- a/pkgs/intl/lib/intl.dart
+++ b/pkgs/intl/lib/intl.dart
@@ -208,7 +208,8 @@ class Intl {
       helpers.verifiedLocale(newLocale, localeExists, onFailure);
 
   /// Return the short version of a locale name, e.g. 'en_US' => 'en'
-  static String shortLocale(String aLocale) => helpers.shortLocale(aLocale);
+  static String shortLocale(String aLocale) =>
+      helpers.languageOnlyLocale(aLocale);
 
   /// Return the name [aLocale] turned into xx_YY where it might possibly be
   /// in the wrong case or with a hyphen instead of an underscore. If

--- a/pkgs/intl/test/intl_test.dart
+++ b/pkgs/intl/test/intl_test.dart
@@ -51,6 +51,10 @@ void main() {
     expect(Intl.verifiedLocale('en-ZZ', NumberFormat.localeExists), 'en');
     expect(Intl.verifiedLocale('es-999', NumberFormat.localeExists), 'es');
     expect(Intl.verifiedLocale('gsw-CH', NumberFormat.localeExists), 'gsw');
+    expect(
+      Intl.verifiedLocale('zh-Hant-CN', NumberFormat.localeExists),
+      'zh_CN',
+    );
 
     void checkAsNumberDefault(String locale, String expected) {
       var oldDefault = Intl.defaultLocale;
@@ -74,6 +78,7 @@ void main() {
     expect(Intl.verifiedLocale('en-ZZ', DateFormat.localeExists), 'en');
     expect(Intl.verifiedLocale('es-999', DateFormat.localeExists), 'es');
     expect(Intl.verifiedLocale('gsw-CH', DateFormat.localeExists), 'gsw');
+    expect(Intl.verifiedLocale('zh-Hant-CN', DateFormat.localeExists), 'zh_CN');
     // TODO(b/241094372): Remove this check.
     expect(Intl.verifiedLocale('invalid', DateFormat.localeExists), 'in');
 

--- a/pkgs/intl/test/number_format_test_core.dart
+++ b/pkgs/intl/test/number_format_test_core.dart
@@ -650,6 +650,17 @@ void runTests(Map<String, num> allTestNumbers) {
       });
     }
   });
+
+  test('Use script', () {
+    expect(
+      NumberFormat.currency(locale: 'zh_Hant_TW').format(12),
+      'TWD12.00',
+    );
+    expect(
+      NumberFormat.currency(locale: 'zh_Hant_CN').format(12),
+      'CNY12.00',
+    );
+  });
 }
 
 String stripExtras(String input) {


### PR DESCRIPTION
Locale strings with a script such as `zh-Hans-CN` are incorrectly canonicalized as `zh` instead of `zh-CN`. Update the `canonicalizedLocale` function to look for a script subtag and ignore it if found.

Closes: https://github.com/dart-lang/i18n/issues/945

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
