### PR TITLE
Small fixes to intl4x

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+
+- Fix fraction digits parsing and allow no hook options key in the pubspec.
+
 ## 0.11.0
 
 - Remove dep on package:js.

--- a/pkgs/intl4x/lib/src/hook_helpers/build_options.dart
+++ b/pkgs/intl4x/lib/src/hook_helpers/build_options.dart
@@ -11,23 +11,27 @@ import 'package:yaml/yaml.dart' show YamlMap, loadYaml;
 Future<BuildOptions?> getBuildOptions(String searchDir) async {
   final map = await readOptionsFromPubspec(searchDir);
   print('Reading build options from $map');
-  final buildOptions =
-  // ignore: avoid_dynamic_calls
-  BuildOptions.fromMap(map['intl4x'] as Map? ?? {});
+  final buildOptions = BuildOptions.fromMap(map?['intl4x'] as Map? ?? {});
   print('Got build options: ${buildOptions.toJson()}');
   return buildOptions;
 }
 
-Future<Map> readOptionsFromPubspec(String searchPath) async {
+Future<YamlMap?> readOptionsFromPubspec(String searchPath) async {
   File pubspec(Directory dir) => File(path.join(dir.path, 'pubspec.yaml'));
 
   var directory = Directory(searchPath);
+  var counter = 0;
   while (!pubspec(directory).existsSync()) {
     directory = directory.parent;
+    counter++;
+    if (counter > 10) {
+      throw ArgumentError('Could not find pubspec at $searchPath');
+    }
   }
 
-  // ignore: avoid_dynamic_calls
-  return loadYaml(pubspec(directory).readAsStringSync())['hook'] as YamlMap;
+  final pubspecYaml =
+      loadYaml(pubspec(directory).readAsStringSync()) as YamlMap;
+  return pubspecYaml['hook'] as YamlMap?;
 }
 
 enum BuildModeEnum { local, checkout, fetch }

--- a/pkgs/intl4x/lib/src/number_format/number_format_options.dart
+++ b/pkgs/intl4x/lib/src/number_format/number_format_options.dart
@@ -268,7 +268,7 @@ final class Digits {
          roundingIncrement == null ||
              ((minimum != null || maximum != null) || minimum == maximum),
        ),
-       assert((minimum == null || maximum == null) || minimum < maximum);
+       assert((minimum == null || maximum == null) || minimum <= maximum);
 
   const Digits.withSignificantDigits({int? minimum = 1, int? maximum = 21})
     : fractionDigits = (null, null),

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 0.11.0
+version: 0.11.1
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 issue_tracker: https://github.com/dart-lang/i18n/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aintl4x
 


### PR DESCRIPTION
Small bug regarding fraction digits parsing and allow no `hook` options key in the pubspec.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
