### PR TITLE
feat!: allow analyzer 7.0.0 and update dart_style to ^3.0.0

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.20.2-wip
-  * Allow analyzer 7.0.0
-  * Update `dart_style` to `^3.0.0`
+## 0.21.0-wip
+  * BREAKING CHANGE: Update `dart_style` to `^3.0.0`
+  * Allow analyzer `>=6.3.0 <8.0.0`
 
 ## 0.20.1
   * Add topics to `pubspec.yaml`

--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.20.2-wip
   * Allow analyzer 7.0.0
+  * Update `dart_style` to `^3.0.0`
 
 ## 0.20.1
   * Add topics to `pubspec.yaml`
-  * Update to `dart_style `2.3.7`. `bin/make_examples_const.dart` and
+  * Update to `dart_style` `2.3.7`. `bin/make_examples_const.dart` and
     `rewrite_intl_messages.dart` will now look for a surrounding
     `.dart_tool/package_config.json` file to infer the language version of the
     files updated by the script.

--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.20.2-wip
+  * Allow analyzer 7.0.0
+
 ## 0.20.1
   * Add topics to `pubspec.yaml`
   * Update to `dart_style `2.3.7`. `bin/make_examples_const.dart` and

--- a/pkgs/intl_translation/lib/src/messages/constant_evaluator.dart
+++ b/pkgs/intl_translation/lib/src/messages/constant_evaluator.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// Needed to wrap `null` as a valid constant value
+class Constant<T extends Object?> {
+  final T value;
+
+  Constant(this.value);
+
+  static Constant<T>? nullable<T extends Object>(T? o) =>
+      o == null ? null : Constant(o);
+}
+
+Constant? evaluate(Expression expression) {
+  return switch (expression) {
+    AdjacentStrings() => Constant.nullable(evaluateConstString(expression)),
+    SimpleStringLiteral() => Constant(expression.value),
+    IntegerLiteral() => Constant(expression.value),
+    DoubleLiteral() => Constant(expression.value),
+    BooleanLiteral() => Constant(expression.value),
+    NullLiteral() => Constant(null),
+    SetOrMapLiteral() => evaluateConstStringMap(expression),
+    _ => null,
+  };
+}
+
+String? evaluateConstString(Expression expression) => switch (expression) {
+      SimpleStringLiteral() => expression.value,
+      AdjacentStrings() => _checkChildren(expression.strings)?.join(),
+      _ => null,
+    };
+
+Iterable<String>? _checkChildren(Iterable<StringLiteral> strings) {
+  final constExpressions = strings.map(
+    (string) => evaluateConstString(string),
+  );
+  return constExpressions.any(
+    (string) => string == null,
+  )
+      ? null
+      : constExpressions.whereType();
+}
+
+Constant<Map>? evaluateConstStringMap(SetOrMapLiteral map) {
+  if (!map.isConst) {
+    return null;
+  }
+  if (map.elements.any(
+    (element) => element is! MapLiteralEntry,
+  )) {
+    return null;
+  }
+  final evaluatedEntries = map.elements.whereType<MapLiteralEntry>().map(
+        (literalEntry) =>
+            (evaluate(literalEntry.key), evaluate(literalEntry.value)),
+      );
+  if (evaluatedEntries
+      .any((element) => element.$1 == null || element.$2 == null)) {
+    return null;
+  }
+  var extractedValues = evaluatedEntries.map(
+    (literalEntry) => MapEntry(literalEntry.$1!.value, literalEntry.$2!.value),
+  );
+  if (extractedValues.any((element) => element.key is! String)) {
+    return null;
+  }
+  return Constant(Map<String, dynamic>.fromEntries(extractedValues.map(
+    (e) => MapEntry(e.key as String, e.value),
+  )));
+}

--- a/pkgs/intl_translation/lib/src/messages/main_message.dart
+++ b/pkgs/intl_translation/lib/src/messages/main_message.dart
@@ -33,7 +33,7 @@ class MainMessage extends ComplexMessage {
   /// Verify that this looks like a correct Intl.message invocation.
   static void checkValidity(
     MethodInvocation node,
-    List arguments,
+    List<Expression> arguments,
     String? outerName,
     List<FormalParameter> outerArgs, {
     bool nameAndArgsGenerated = false,

--- a/pkgs/intl_translation/lib/src/messages/message.dart
+++ b/pkgs/intl_translation/lib/src/messages/message.dart
@@ -38,6 +38,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 
 import 'complex_message.dart';
 import 'composite_message.dart';
+import 'constant_evaluator.dart';
 import 'literal_string_message.dart';
 import 'message_extraction_exception.dart';
 import 'variable_substitution_message.dart';
@@ -223,7 +224,7 @@ abstract class Message {
       if (examples.isNotEmpty) {
         var example = examples.first;
         if (example is SetOrMapLiteral) {
-          if (!_isConstMap(example)) {
+          if (evaluateConstStringMap(example) == null) {
             throw MessageExtractionException(
                 'Examples must be a const Map literal.');
           } else if (example.constKeyword == null) {
@@ -350,30 +351,4 @@ abstract class Message {
   /// applied to any sub-messages, allowing this to be used to generate a form
   /// suitable for a wide variety of translation file formats.
   String expanded([String Function(Message, Object) transform]);
-}
-
-String? evaluateConstString(Expression expression) => switch (expression) {
-      SimpleStringLiteral() => expression.value,
-      AdjacentStrings() => _checkChildren(expression.strings)?.join(),
-      _ => null,
-    };
-
-Iterable<String>? _checkChildren(Iterable<StringLiteral> strings) {
-  final constExpressions = strings.map(
-    (string) => evaluateConstString(string),
-  );
-  return constExpressions.any(
-    (string) => string == null,
-  )
-      ? null
-      : constExpressions.whereType();
-}
-
-bool _isConstMap(SetOrMapLiteral map) {
-  if (map.elements.any(
-    (element) => element is! MapLiteralEntry,
-  )) {
-    return false;
-  }
-  return map.isConst;
 }

--- a/pkgs/intl_translation/lib/src/messages/message.dart
+++ b/pkgs/intl_translation/lib/src/messages/message.dart
@@ -358,7 +358,7 @@ String? evaluateConstString(Expression expression) => switch (expression) {
       _ => null,
     };
 
-Iterable<String>? _checkChildren<T>(Iterable<StringLiteral> strings) {
+Iterable<String>? _checkChildren(Iterable<StringLiteral> strings) {
   final constExpressions = strings.map(
     (string) => evaluateConstString(string),
   );

--- a/pkgs/intl_translation/lib/visitors/message_finding_visitor.dart
+++ b/pkgs/intl_translation/lib/visitors/message_finding_visitor.dart
@@ -4,10 +4,9 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/dart/ast/constant_evaluator.dart';
 
 import '../extract_messages.dart';
+import '../src/messages/constant_evaluator.dart';
 import '../src/messages/main_message.dart';
 import '../src/messages/message.dart';
 import '../src/messages/message_extraction_exception.dart';
@@ -288,10 +287,8 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
     for (var namedExpr in arguments.whereType<NamedExpression>()) {
       var name = namedExpr.name.label.name;
       var exp = namedExpr.expression;
-      var basicValue = exp.accept(ConstantEvaluator());
-      var value = basicValue == ConstantEvaluator.NOT_A_CONSTANT
-          ? exp.toString()
-          : basicValue;
+      var constant = evaluate(exp);
+      var value = constant == null ? exp.toString() : constant.value;
       setAttribute(message, name, value);
     }
     // We only rewrite messages with parameters, otherwise we use the literal

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   analyzer: ">=6.3.0 <8.0.0"
   args: ^2.0.0
-  dart_style: ^2.0.0
+  dart_style: ^3.0.0
   intl: '>=0.19.0 <0.21.0'
   package_config: ^2.1.0
   path: ^1.0.0

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.20.2-wip
+version: 0.21.0-wip
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  analyzer: ^6.3.0
+  analyzer: ">=6.3.0 <8.0.0"
   args: ^2.0.0
   dart_style: ^2.0.0
   intl: '>=0.19.0 <0.21.0'

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.20.1
+version: 0.20.2-wip
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and

--- a/pkgs/intl_translation/test/constant_evaluator_test.dart
+++ b/pkgs/intl_translation/test/constant_evaluator_test.dart
@@ -10,162 +10,83 @@ import 'package:test/test.dart';
 
 void main() {
   group('Constant class', () {
-    test('should wrap non-null values', () {
-      final constant = Constant('test');
-      expect(constant.value, 'test');
+    test('should wrap values including null', () {
+      final stringConstant = Constant('test');
+      expect(stringConstant.value, 'test');
+
+      final nullConstant = Constant<String?>(null);
+      expect(nullConstant.value, isNull);
     });
 
-    test('should wrap null values', () {
-      final constant = Constant<String?>(null);
-      expect(constant.value, isNull);
-    });
+    test('nullable should handle null and non-null values', () {
+      expect(Constant.nullable<String>(null), isNull);
 
-    test('nullable should return null for null input', () {
-      final result = Constant.nullable<String>(null);
-      expect(result, isNull);
-    });
-
-    test('nullable should wrap non-null values', () {
       final result = Constant.nullable('test');
-      expect(result, isNotNull);
       expect(result!.value, 'test');
     });
   });
 
   group('evaluate function', () {
-    test('should evaluate SimpleStringLiteral', () {
-      final expression =
-          _parseExpression('"hello world"') as SimpleStringLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, 'hello world');
+    test('should evaluate all basic literal types', () {
+      expect(
+          evaluate(_parseExpression('"hello"') as SimpleStringLiteral)!.value,
+          'hello');
+      expect(evaluate(_parseExpression('42') as IntegerLiteral)!.value, 42);
+      expect(evaluate(_parseExpression('3.14') as DoubleLiteral)!.value, 3.14);
+      expect(evaluate(_parseExpression('true') as BooleanLiteral)!.value, true);
+      expect(evaluate(_parseExpression('null') as NullLiteral)!.value, isNull);
     });
 
     test('should evaluate AdjacentStrings', () {
-      final expression =
-          _parseExpression('"hello " "world"') as AdjacentStrings;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
+      final result =
+          evaluate(_parseExpression('"hello " "world"') as AdjacentStrings);
       expect(result!.value, 'hello world');
     });
 
-    test('should evaluate IntegerLiteral', () {
-      final expression = _parseExpression('42') as IntegerLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, 42);
-    });
-
-    test('should evaluate DoubleLiteral', () {
-      final expression = _parseExpression('3.14') as DoubleLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, 3.14);
-    });
-
-    test('should evaluate BooleanLiteral true', () {
-      final expression = _parseExpression('true') as BooleanLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, true);
-    });
-
-    test('should evaluate BooleanLiteral false', () {
-      final expression = _parseExpression('false') as BooleanLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, false);
-    });
-
-    test('should evaluate NullLiteral', () {
-      final expression = _parseExpression('null') as NullLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, isNull);
-    });
-
-    test('should evaluate const SetOrMapLiteral (map)', () {
-      final expression = _parseExpression('const {"key": "value", "num": 42}')
-          as SetOrMapLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, isA<Map<String, dynamic>>());
-      final map = result.value as Map<String, dynamic>;
+    test('should evaluate const maps', () {
+      final result = evaluate(
+          _parseExpression('const {"key": "value", "num": 42}')
+              as SetOrMapLiteral);
+      final map = result!.value as Map<String, dynamic>;
       expect(map['key'], 'value');
       expect(map['num'], 42);
     });
 
     test('should return null for unsupported expressions', () {
-      final expression = _parseExpression('someVariable') as SimpleIdentifier;
-      final result = evaluate(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for function calls', () {
-      final expression = _parseExpression('someFunction()') as MethodInvocation;
-      final result = evaluate(expression);
-
-      expect(result, isNull);
+      expect(evaluate(_parseExpression('someVariable') as SimpleIdentifier),
+          isNull);
+      expect(evaluate(_parseExpression('someFunction()') as MethodInvocation),
+          isNull);
     });
   });
 
   group('evaluateConstString function', () {
-    test('should evaluate SimpleStringLiteral', () {
-      final expression = _parseExpression('"hello"') as SimpleStringLiteral;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'hello');
-    });
-
-    test('should evaluate AdjacentStrings with multiple parts', () {
-      final expression =
-          _parseExpression('"hello " "beautiful " "world"') as AdjacentStrings;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'hello beautiful world');
-    });
-
-    test('should evaluate AdjacentStrings with empty string', () {
-      final expression =
-          _parseExpression('"hello" "" "world"') as AdjacentStrings;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'helloworld');
+    test('should evaluate string literals and adjacent strings', () {
+      expect(
+          evaluateConstString(
+              _parseExpression('"hello"') as SimpleStringLiteral),
+          'hello');
+      expect(
+          evaluateConstString(
+              _parseExpression('"hello " "world"') as AdjacentStrings),
+          'hello world');
     });
 
     test('should return null for non-string expressions', () {
-      final expression = _parseExpression('42') as IntegerLiteral;
-      final result = evaluateConstString(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for string interpolation', () {
-      final expression =
-          _parseExpression(r'"hello ${variable}"') as StringInterpolation;
-      final result = evaluateConstString(expression);
-
-      expect(result, isNull);
+      expect(evaluateConstString(_parseExpression('42') as IntegerLiteral),
+          isNull);
+      expect(
+          evaluateConstString(
+              _parseExpression(r'"hello ${variable}"') as StringInterpolation),
+          isNull);
     });
   });
 
   group('evaluateConstStringMap function', () {
-    test('should evaluate const map with string keys and mixed values', () {
-      final expression = _parseExpression(
+    test('should evaluate const maps with string keys', () {
+      final result = evaluateConstStringMap(_parseExpression(
               'const {"str": "value", "num": 42, "bool": true, "nil": null}')
-          as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNotNull);
+          as SetOrMapLiteral);
       final map = result!.value as Map<String, dynamic>;
       expect(map['str'], 'value');
       expect(map['num'], 42);
@@ -173,276 +94,39 @@ void main() {
       expect(map['nil'], isNull);
     });
 
-    test('should evaluate const empty map', () {
-      final expression =
-          _parseExpression('const <String, dynamic>{}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNotNull);
-      expect(result!.value, isA<Map<String, dynamic>>());
-      expect((result.value).isEmpty, isTrue);
-    });
-
-    test('should return null for non-const map', () {
-      final expression =
-          _parseExpression('{"key": "value"}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for const set', () {
-      final expression =
-          _parseExpression('const {"item1", "item2"}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for map with spread elements', () {
-      final expression =
-          _parseExpression('const {...other}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for map with non-evaluable keys', () {
-      final expression =
-          _parseExpression('const {someVariable: "value"}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for map with non-evaluable values', () {
-      final expression =
-          _parseExpression('const {"key": someVariable}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should return null for map with non-string keys', () {
-      final expression =
-          _parseExpression('const {42: "value"}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should handle nested const maps', () {
-      final expression =
-          _parseExpression('const {"outer": const {"inner": "value"}}')
-              as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNotNull);
+    test('should handle nested maps and adjacent strings', () {
+      final result = evaluateConstStringMap(
+          _parseExpression('const {"outer": const {"inner": "hello " "world"}}')
+              as SetOrMapLiteral);
       final outerMap = result!.value as Map<String, dynamic>;
-      expect(outerMap['outer'], isA<Map<String, dynamic>>());
       final innerMap = outerMap['outer'] as Map<String, dynamic>;
-      expect(innerMap['inner'], 'value');
-    });
-  });
-
-  group('Recursive and complex scenarios', () {
-    test('should handle nested AdjacentStrings in map values', () {
-      final expression = _parseExpression('const {"key": "hello " "world"}')
-          as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNotNull);
-      final map = result!.value as Map<String, dynamic>;
-      expect(map['key'], 'hello world');
+      expect(innerMap['inner'], 'hello world');
     });
 
-    test('should handle nested AdjacentStrings in map keys', () {
-      final expression = _parseExpression('const {"hello " "world": "value"}')
-          as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
+    test('should return null for invalid cases', () {
+      // Non-const map
+      expect(
+          evaluateConstStringMap(
+              _parseExpression('{"key": "value"}') as SetOrMapLiteral),
+          isNull);
 
-      expect(result, isNotNull);
-      final map = result!.value as Map<String, dynamic>;
-      expect(map['hello world'], 'value');
-    });
+      // Const set (not map)
+      expect(
+          evaluateConstStringMap(
+              _parseExpression('const {"item1", "item2"}') as SetOrMapLiteral),
+          isNull);
 
-    test('should handle deeply nested const structures', () {
-      final expression = _parseExpression('''
-        const {
-          "level1": const {
-            "level2": const {
-              "level3": "deep " "value"
-            }
-          }
-        }
-      ''') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
+      // Non-string keys
+      expect(
+          evaluateConstStringMap(
+              _parseExpression('const {42: "value"}') as SetOrMapLiteral),
+          isNull);
 
-      expect(result, isNotNull);
-      final level1 = result!.value as Map<String, dynamic>;
-      final level2 = level1['level1'] as Map<String, dynamic>;
-      final level3 = level2['level2'] as Map<String, dynamic>;
-      expect(level3['level3'], 'deep value');
-    });
-
-    test('should handle AdjacentStrings with many parts', () {
-      final expression =
-          _parseExpression('"a" "b" "c" "d" "e"') as AdjacentStrings;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'abcde');
-    });
-
-    test('should handle complex map with all supported literal types', () {
-      final expression = _parseExpression('''
-        const {
-          "string": "hello " "world",
-          "integer": 42,
-          "double": 3.14,
-          "boolean_true": true,
-          "boolean_false": false,
-          "null_value": null,
-          "nested_map": const {
-            "inner": "value"
-          }
-        }
-      ''') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNotNull);
-      final map = result!.value as Map<String, dynamic>;
-      expect(map['string'], 'hello world');
-      expect(map['integer'], 42);
-      expect(map['double'], 3.14);
-      expect(map['boolean_true'], true);
-      expect(map['boolean_false'], false);
-      expect(map['null_value'], isNull);
-      expect(map['nested_map'], isA<Map<String, dynamic>>());
-      final nestedMap = map['nested_map'] as Map<String, dynamic>;
-      expect(nestedMap['inner'], 'value');
-    });
-
-    test('should handle AdjacentStrings with non-evaluable children', () {
-      final identifierExpression =
-          _parseExpression('someVariable') as SimpleIdentifier;
-      final result = evaluateConstString(identifierExpression);
-
-      expect(result, isNull);
-    });
-
-    test('should handle empty string in AdjacentStrings', () {
-      final expression = _parseExpression('""') as SimpleStringLiteral;
-      final result = evaluateConstString(expression);
-
-      expect(result, '');
-    });
-  });
-
-  group('Edge cases and error conditions', () {
-    test('evaluate should handle very large integers', () {
-      final expression = _parseExpression('9223372036854775807')
-          as IntegerLiteral; // Max int64
-      final result = evaluate(expression);
-
-      expect(result!.value, 9223372036854775807);
-    });
-
-    test('evaluate should handle negative integers', () {
-      final expression = _parseExpression('-42') as PrefixExpression;
-      final result = evaluate(expression);
-
-      expect(result, isNull);
-    });
-
-    test('evaluate should handle very small doubles', () {
-      final expression = _parseExpression('1e-100') as DoubleLiteral;
-      final result = evaluate(expression);
-
-      expect(result!.value, 1e-100);
-    });
-
-    test('evaluateConstStringMap should handle map with duplicate keys', () {
-      final expression =
-          _parseExpression('const {"key": "first", "key": "second"}')
-              as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      final map = result!.value as Map<String, dynamic>;
-      expect(map['key'], 'second');
-    });
-
-    test('should handle mixed string types in AdjacentStrings', () {
-      // Test with single and double quoted strings
-      final expression =
-          _parseExpression("'single' \"double\"") as AdjacentStrings;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'singledouble');
-    });
-
-    test('should handle escape sequences in strings', () {
-      final expression =
-          _parseExpression(r'"hello\nworld"') as SimpleStringLiteral;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'hello\nworld');
-    });
-
-    test('should handle const list', () {
-      final expression = _parseExpression('const [1, 2, 3]') as ListLiteral;
-      final result = evaluate(expression);
-
-      expect(result, isNull);
-    });
-  });
-
-  group('_checkChildren helper function edge cases', () {
-    test('should handle empty AdjacentStrings', () {
-      final expression = _parseExpression('"" ""') as AdjacentStrings;
-      final result = evaluateConstString(expression);
-
-      expect(result, '');
-    });
-
-    test('should handle single string in AdjacentStrings', () {
-      final expression = _parseExpression('"single"') as SimpleStringLiteral;
-      final result = evaluateConstString(expression);
-
-      expect(result, 'single');
-    });
-  });
-
-  group('Additional coverage for completeness', () {
-    test('should handle const map with if elements', () {
-      final expression = _parseExpression('const {if (true) "key": "value"}')
-          as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should handle const map with for elements', () {
-      final expression = _parseExpression('const {for (var i in items) i: i}')
-          as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should handle map with null key', () {
-      final expression =
-          _parseExpression('const {null: "value"}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
-    });
-
-    test('should handle map with boolean key', () {
-      final expression =
-          _parseExpression('const {true: "value"}') as SetOrMapLiteral;
-      final result = evaluateConstStringMap(expression);
-
-      expect(result, isNull);
+      // Non-evaluable values
+      expect(
+          evaluateConstStringMap(_parseExpression('const {"key": someVariable}')
+              as SetOrMapLiteral),
+          isNull);
     });
   });
 }

--- a/pkgs/intl_translation/test/constant_evaluator_test.dart
+++ b/pkgs/intl_translation/test/constant_evaluator_test.dart
@@ -1,0 +1,461 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:intl_translation/src/messages/constant_evaluator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Constant class', () {
+    test('should wrap non-null values', () {
+      final constant = Constant('test');
+      expect(constant.value, 'test');
+    });
+
+    test('should wrap null values', () {
+      final constant = Constant<String?>(null);
+      expect(constant.value, isNull);
+    });
+
+    test('nullable should return null for null input', () {
+      final result = Constant.nullable<String>(null);
+      expect(result, isNull);
+    });
+
+    test('nullable should wrap non-null values', () {
+      final result = Constant.nullable('test');
+      expect(result, isNotNull);
+      expect(result!.value, 'test');
+    });
+  });
+
+  group('evaluate function', () {
+    test('should evaluate SimpleStringLiteral', () {
+      final expression =
+          _parseExpression('"hello world"') as SimpleStringLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, 'hello world');
+    });
+
+    test('should evaluate AdjacentStrings', () {
+      final expression =
+          _parseExpression('"hello " "world"') as AdjacentStrings;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, 'hello world');
+    });
+
+    test('should evaluate IntegerLiteral', () {
+      final expression = _parseExpression('42') as IntegerLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, 42);
+    });
+
+    test('should evaluate DoubleLiteral', () {
+      final expression = _parseExpression('3.14') as DoubleLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, 3.14);
+    });
+
+    test('should evaluate BooleanLiteral true', () {
+      final expression = _parseExpression('true') as BooleanLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, true);
+    });
+
+    test('should evaluate BooleanLiteral false', () {
+      final expression = _parseExpression('false') as BooleanLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, false);
+    });
+
+    test('should evaluate NullLiteral', () {
+      final expression = _parseExpression('null') as NullLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, isNull);
+    });
+
+    test('should evaluate const SetOrMapLiteral (map)', () {
+      final expression = _parseExpression('const {"key": "value", "num": 42}')
+          as SetOrMapLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, isA<Map<String, dynamic>>());
+      final map = result.value as Map<String, dynamic>;
+      expect(map['key'], 'value');
+      expect(map['num'], 42);
+    });
+
+    test('should return null for unsupported expressions', () {
+      final expression = _parseExpression('someVariable') as SimpleIdentifier;
+      final result = evaluate(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for function calls', () {
+      final expression = _parseExpression('someFunction()') as MethodInvocation;
+      final result = evaluate(expression);
+
+      expect(result, isNull);
+    });
+  });
+
+  group('evaluateConstString function', () {
+    test('should evaluate SimpleStringLiteral', () {
+      final expression = _parseExpression('"hello"') as SimpleStringLiteral;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'hello');
+    });
+
+    test('should evaluate AdjacentStrings with multiple parts', () {
+      final expression =
+          _parseExpression('"hello " "beautiful " "world"') as AdjacentStrings;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'hello beautiful world');
+    });
+
+    test('should evaluate AdjacentStrings with empty string', () {
+      final expression =
+          _parseExpression('"hello" "" "world"') as AdjacentStrings;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'helloworld');
+    });
+
+    test('should return null for non-string expressions', () {
+      final expression = _parseExpression('42') as IntegerLiteral;
+      final result = evaluateConstString(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for string interpolation', () {
+      final expression =
+          _parseExpression(r'"hello ${variable}"') as StringInterpolation;
+      final result = evaluateConstString(expression);
+
+      expect(result, isNull);
+    });
+  });
+
+  group('evaluateConstStringMap function', () {
+    test('should evaluate const map with string keys and mixed values', () {
+      final expression = _parseExpression(
+              'const {"str": "value", "num": 42, "bool": true, "nil": null}')
+          as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      final map = result!.value as Map<String, dynamic>;
+      expect(map['str'], 'value');
+      expect(map['num'], 42);
+      expect(map['bool'], true);
+      expect(map['nil'], isNull);
+    });
+
+    test('should evaluate const empty map', () {
+      final expression =
+          _parseExpression('const <String, dynamic>{}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      expect(result!.value, isA<Map<String, dynamic>>());
+      expect((result.value).isEmpty, isTrue);
+    });
+
+    test('should return null for non-const map', () {
+      final expression =
+          _parseExpression('{"key": "value"}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for const set', () {
+      final expression =
+          _parseExpression('const {"item1", "item2"}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for map with spread elements', () {
+      final expression =
+          _parseExpression('const {...other}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for map with non-evaluable keys', () {
+      final expression =
+          _parseExpression('const {someVariable: "value"}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for map with non-evaluable values', () {
+      final expression =
+          _parseExpression('const {"key": someVariable}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should return null for map with non-string keys', () {
+      final expression =
+          _parseExpression('const {42: "value"}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should handle nested const maps', () {
+      final expression =
+          _parseExpression('const {"outer": const {"inner": "value"}}')
+              as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      final outerMap = result!.value as Map<String, dynamic>;
+      expect(outerMap['outer'], isA<Map<String, dynamic>>());
+      final innerMap = outerMap['outer'] as Map<String, dynamic>;
+      expect(innerMap['inner'], 'value');
+    });
+  });
+
+  group('Recursive and complex scenarios', () {
+    test('should handle nested AdjacentStrings in map values', () {
+      final expression = _parseExpression('const {"key": "hello " "world"}')
+          as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      final map = result!.value as Map<String, dynamic>;
+      expect(map['key'], 'hello world');
+    });
+
+    test('should handle nested AdjacentStrings in map keys', () {
+      final expression = _parseExpression('const {"hello " "world": "value"}')
+          as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      final map = result!.value as Map<String, dynamic>;
+      expect(map['hello world'], 'value');
+    });
+
+    test('should handle deeply nested const structures', () {
+      final expression = _parseExpression('''
+        const {
+          "level1": const {
+            "level2": const {
+              "level3": "deep " "value"
+            }
+          }
+        }
+      ''') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      final level1 = result!.value as Map<String, dynamic>;
+      final level2 = level1['level1'] as Map<String, dynamic>;
+      final level3 = level2['level2'] as Map<String, dynamic>;
+      expect(level3['level3'], 'deep value');
+    });
+
+    test('should handle AdjacentStrings with many parts', () {
+      final expression =
+          _parseExpression('"a" "b" "c" "d" "e"') as AdjacentStrings;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'abcde');
+    });
+
+    test('should handle complex map with all supported literal types', () {
+      final expression = _parseExpression('''
+        const {
+          "string": "hello " "world",
+          "integer": 42,
+          "double": 3.14,
+          "boolean_true": true,
+          "boolean_false": false,
+          "null_value": null,
+          "nested_map": const {
+            "inner": "value"
+          }
+        }
+      ''') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNotNull);
+      final map = result!.value as Map<String, dynamic>;
+      expect(map['string'], 'hello world');
+      expect(map['integer'], 42);
+      expect(map['double'], 3.14);
+      expect(map['boolean_true'], true);
+      expect(map['boolean_false'], false);
+      expect(map['null_value'], isNull);
+      expect(map['nested_map'], isA<Map<String, dynamic>>());
+      final nestedMap = map['nested_map'] as Map<String, dynamic>;
+      expect(nestedMap['inner'], 'value');
+    });
+
+    test('should handle AdjacentStrings with non-evaluable children', () {
+      final identifierExpression =
+          _parseExpression('someVariable') as SimpleIdentifier;
+      final result = evaluateConstString(identifierExpression);
+
+      expect(result, isNull);
+    });
+
+    test('should handle empty string in AdjacentStrings', () {
+      final expression = _parseExpression('""') as SimpleStringLiteral;
+      final result = evaluateConstString(expression);
+
+      expect(result, '');
+    });
+  });
+
+  group('Edge cases and error conditions', () {
+    test('evaluate should handle very large integers', () {
+      final expression = _parseExpression('9223372036854775807')
+          as IntegerLiteral; // Max int64
+      final result = evaluate(expression);
+
+      expect(result!.value, 9223372036854775807);
+    });
+
+    test('evaluate should handle negative integers', () {
+      final expression = _parseExpression('-42') as PrefixExpression;
+      final result = evaluate(expression);
+
+      expect(result, isNull);
+    });
+
+    test('evaluate should handle very small doubles', () {
+      final expression = _parseExpression('1e-100') as DoubleLiteral;
+      final result = evaluate(expression);
+
+      expect(result!.value, 1e-100);
+    });
+
+    test('evaluateConstStringMap should handle map with duplicate keys', () {
+      final expression =
+          _parseExpression('const {"key": "first", "key": "second"}')
+              as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      final map = result!.value as Map<String, dynamic>;
+      expect(map['key'], 'second');
+    });
+
+    test('should handle mixed string types in AdjacentStrings', () {
+      // Test with single and double quoted strings
+      final expression =
+          _parseExpression("'single' \"double\"") as AdjacentStrings;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'singledouble');
+    });
+
+    test('should handle escape sequences in strings', () {
+      final expression =
+          _parseExpression(r'"hello\nworld"') as SimpleStringLiteral;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'hello\nworld');
+    });
+
+    test('should handle const list', () {
+      final expression = _parseExpression('const [1, 2, 3]') as ListLiteral;
+      final result = evaluate(expression);
+
+      expect(result, isNull);
+    });
+  });
+
+  group('_checkChildren helper function edge cases', () {
+    test('should handle empty AdjacentStrings', () {
+      final expression = _parseExpression('"" ""') as AdjacentStrings;
+      final result = evaluateConstString(expression);
+
+      expect(result, '');
+    });
+
+    test('should handle single string in AdjacentStrings', () {
+      final expression = _parseExpression('"single"') as SimpleStringLiteral;
+      final result = evaluateConstString(expression);
+
+      expect(result, 'single');
+    });
+  });
+
+  group('Additional coverage for completeness', () {
+    test('should handle const map with if elements', () {
+      final expression = _parseExpression('const {if (true) "key": "value"}')
+          as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should handle const map with for elements', () {
+      final expression = _parseExpression('const {for (var i in items) i: i}')
+          as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should handle map with null key', () {
+      final expression =
+          _parseExpression('const {null: "value"}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+
+    test('should handle map with boolean key', () {
+      final expression =
+          _parseExpression('const {true: "value"}') as SetOrMapLiteral;
+      final result = evaluateConstStringMap(expression);
+
+      expect(result, isNull);
+    });
+  });
+}
+
+/// Helper function to parse a single expression from a string
+Expression _parseExpression(String code) {
+  final unit = parseString(
+    content: 'var x = $code;',
+    featureSet: FeatureSet.latestLanguageVersion(),
+  ).unit;
+
+  final variableDeclaration =
+      unit.declarations.first as TopLevelVariableDeclaration;
+  final variable = variableDeclaration.variables.variables.first;
+  return variable.initializer!;
+}

--- a/pkgs/intl_translation/test/generate_localized/code_map_messages_all.dart
+++ b/pkgs/intl_translation/test/generate_localized/code_map_messages_all.dart
@@ -1,9 +1,12 @@
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
+// @dart=2.12
 
 import 'package:intl/intl.dart';
-export 'code_map_messages_all_locales.dart' show initializeMessages;
+export 'code_map_messages_all_locales.dart'
+  show initializeMessages;
+
 
 /// Turn the JSON template into a string.
 ///
@@ -26,39 +29,44 @@ String? evaluateJsonTemplate(dynamic input, List<dynamic> args) {
   var template = input as List<dynamic>;
   var messageName = template.first;
   if (messageName == 'Intl.plural') {
-    var howMany = args[template[1] as int] as num;
-    return evaluateJsonTemplate(
-        Intl.pluralLogic(howMany,
-            zero: template[2],
-            one: template[3],
-            two: template[4],
-            few: template[5],
-            many: template[6],
-            other: template[7]),
-        args);
-  }
-  if (messageName == 'Intl.gender') {
-    var gender = args[template[1] as int] as String;
-    return evaluateJsonTemplate(
-        Intl.genderLogic(gender,
-            female: template[2], male: template[3], other: template[4]),
-        args);
-  }
-  if (messageName == 'Intl.select') {
-    var select = args[template[1] as int] as Object;
-    var choices = template[2] as Map<Object, Object?>;
-    return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
+     var howMany = args[template[1] as int] as num;
+     return evaluateJsonTemplate(
+         Intl.pluralLogic(
+             howMany,
+             zero: template[2],
+             one: template[3],
+             two: template[4],
+             few: template[5],
+             many: template[6],
+             other: template[7]),
+         args);
+   }
+   if (messageName == 'Intl.gender') {
+     var gender = args[template[1] as int] as String;
+     return evaluateJsonTemplate(
+         Intl.genderLogic(
+             gender,
+             female: template[2],
+             male: template[3],
+             other: template[4]),
+         args);
+   }
+   if (messageName == 'Intl.select') {
+     var select = args[template[1] as int] as Object;
+     var choices = template[2] as Map<Object, Object?>;
+     return evaluateJsonTemplate(Intl.selectLogic(select, choices), args);
+   }
+
+   // If we get this far, then we are a basic interpolation, just strings and
+   // ints.
+   var output = StringBuffer();
+   for (var entry in template) {
+     if (entry is int) {
+       output.write('${args[entry]}');
+     } else {
+       output.write('$entry');
+     }
+   }
+   return output.toString();
   }
 
-  // If we get this far, then we are a basic interpolation, just strings and
-  // ints.
-  var output = StringBuffer();
-  for (var entry in template) {
-    if (entry is int) {
-      output.write('${args[entry]}');
-    } else {
-      output.write('$entry');
-    }
-  }
-  return output.toString();
-}

--- a/pkgs/intl_translation/test/generate_localized/code_map_messages_all_locales.dart
+++ b/pkgs/intl_translation/test/generate_localized/code_map_messages_all_locales.dart
@@ -1,7 +1,7 @@
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
-
+// @dart=2.12
 // Ignore issues from commonly used lints in this file.
 // ignore_for_file:implementation_imports, file_names
 // ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
@@ -32,8 +32,9 @@ MessageLookupByLibrary? _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String? localeName) async {
   var availableLocale = Intl.verifiedLocale(
-      localeName, (locale) => _deferredLibraries[locale] != null,
-      onFailure: (_) => null);
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
   if (availableLocale == null) {
     return Future.value(false);
   }
@@ -53,8 +54,8 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary? _findGeneratedMessagesFor(String locale) {
-  var actualLocale =
-      Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/pkgs/intl_translation/test/generate_localized/code_map_messages_fr.dart
+++ b/pkgs/intl_translation/test/generate_localized/code_map_messages_fr.dart
@@ -2,7 +2,7 @@
 // This is a library that provides messages for a fr locale. All the
 // messages from the main program should be duplicated here with the same
 // function name.
-
+// @dart=2.12
 // Ignore issues from commonly used lints in this file.
 // ignore_for_file:unnecessary_brace_in_string_interps
 // ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
@@ -19,18 +19,18 @@ import 'dart:collection';
 
 final messages = MessageLookup();
 
-typedef String? MessageIfAbsent(String? messageStr, List<Object>? args);
+typedef String? MessageIfAbsent(
+    String? messageStr, List<Object>? args);
 
 class MessageLookup extends MessageLookupByLibrary {
   @override
   String get localeName => 'fr';
 
+
   String? evaluateMessage(dynamic translation, List<dynamic> args) {
     return evaluateJsonTemplate(translation, args);
   }
-
   Map<String, dynamic> get messages => _constMessages;
-  static const _constMessages = <String, Object?>{
-    "Hello from application": "Bonjour de l'application"
-  };
+  static const _constMessages = <String, Object?>{"Hello from application":<Object?>["Bonjour de l'application"]};
+
 }

--- a/pkgs/intl_translation/test/two_components/app_messages_all.dart
+++ b/pkgs/intl_translation/test/two_components/app_messages_all.dart
@@ -1,5 +1,7 @@
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
+// @dart=2.12
+export 'app_messages_all_locales.dart'
+  show initializeMessages;
 
-export 'app_messages_all_locales.dart' show initializeMessages;

--- a/pkgs/intl_translation/test/two_components/app_messages_all_locales.dart
+++ b/pkgs/intl_translation/test/two_components/app_messages_all_locales.dart
@@ -1,7 +1,7 @@
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
-
+// @dart=2.12
 // Ignore issues from commonly used lints in this file.
 // ignore_for_file:implementation_imports, file_names
 // ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
@@ -32,8 +32,9 @@ MessageLookupByLibrary? _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String? localeName) async {
   var availableLocale = Intl.verifiedLocale(
-      localeName, (locale) => _deferredLibraries[locale] != null,
-      onFailure: (_) => null);
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
   if (availableLocale == null) {
     return Future.value(false);
   }
@@ -53,8 +54,8 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary? _findGeneratedMessagesFor(String locale) {
-  var actualLocale =
-      Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/pkgs/intl_translation/test/two_components/app_messages_fr.dart
+++ b/pkgs/intl_translation/test/two_components/app_messages_fr.dart
@@ -2,7 +2,7 @@
 // This is a library that provides messages for a fr locale. All the
 // messages from the main program should be duplicated here with the same
 // function name.
-
+// @dart=2.12
 // Ignore issues from commonly used lints in this file.
 // ignore_for_file:unnecessary_brace_in_string_interps
 // ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
@@ -14,18 +14,17 @@ import 'package:intl/message_lookup_by_library.dart';
 
 final messages = MessageLookup();
 
-typedef String? MessageIfAbsent(String? messageStr, List<Object>? args);
+typedef String? MessageIfAbsent(
+    String? messageStr, List<Object>? args);
 
 class MessageLookup extends MessageLookupByLibrary {
   @override
   String get localeName => 'fr';
 
   @override
-  final Map<String, dynamic> messages =
-      _notInlinedMessages(_notInlinedMessages);
+  final Map<String, dynamic> messages = _notInlinedMessages(_notInlinedMessages);
 
   static Map<String, dynamic> _notInlinedMessages(_) => {
-        'Hello from application':
-            MessageLookupByLibrary.simpleMessage('Bonjour de l\'application')
-      };
+      'Hello from application': MessageLookupByLibrary.simpleMessage('Bonjour de l\'application')
+  };
 }

--- a/pkgs/intl_translation/test/two_components/component_messages_all.dart
+++ b/pkgs/intl_translation/test/two_components/component_messages_all.dart
@@ -1,5 +1,7 @@
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
+// @dart=2.12
+export 'component_messages_all_locales.dart'
+  show initializeMessages;
 
-export 'component_messages_all_locales.dart' show initializeMessages;

--- a/pkgs/intl_translation/test/two_components/component_messages_all_locales.dart
+++ b/pkgs/intl_translation/test/two_components/component_messages_all_locales.dart
@@ -1,7 +1,7 @@
 // DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
 // This is a library that looks up messages for specific locales by
 // delegating to the appropriate library.
-
+// @dart=2.12
 // Ignore issues from commonly used lints in this file.
 // ignore_for_file:implementation_imports, file_names
 // ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
@@ -32,8 +32,9 @@ MessageLookupByLibrary? _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String? localeName) async {
   var availableLocale = Intl.verifiedLocale(
-      localeName, (locale) => _deferredLibraries[locale] != null,
-      onFailure: (_) => null);
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
   if (availableLocale == null) {
     return Future.value(false);
   }
@@ -53,8 +54,8 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary? _findGeneratedMessagesFor(String locale) {
-  var actualLocale =
-      Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/pkgs/intl_translation/test/two_components/component_messages_fr_xyz123.dart
+++ b/pkgs/intl_translation/test/two_components/component_messages_fr_xyz123.dart
@@ -2,7 +2,7 @@
 // This is a library that provides messages for a fr_xyz123 locale. All the
 // messages from the main program should be duplicated here with the same
 // function name.
-
+// @dart=2.12
 // Ignore issues from commonly used lints in this file.
 // ignore_for_file:unnecessary_brace_in_string_interps
 // ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
@@ -14,19 +14,18 @@ import 'package:intl/message_lookup_by_library.dart';
 
 final messages = MessageLookup();
 
-typedef String? MessageIfAbsent(String? messageStr, List<Object>? args);
+typedef String? MessageIfAbsent(
+    String? messageStr, List<Object>? args);
 
 class MessageLookup extends MessageLookupByLibrary {
   @override
   String get localeName => 'fr_xyz123';
 
   @override
-  final Map<String, dynamic> messages =
-      _notInlinedMessages(_notInlinedMessages);
+  final Map<String, dynamic> messages = _notInlinedMessages(_notInlinedMessages);
 
   static Map<String, dynamic> _notInlinedMessages(_) => {
-        'Hello from component':
-            MessageLookupByLibrary.simpleMessage('Bonjour du composant'),
-        '_message2': MessageLookupByLibrary.simpleMessage('Locale explicite')
-      };
+      'Hello from component': MessageLookupByLibrary.simpleMessage('Bonjour du composant'),
+    '_message2': MessageLookupByLibrary.simpleMessage('Locale explicite')
+  };
 }


### PR DESCRIPTION
Allows analyzer version ^7.0.0 and update dart_style to ^3.0.0.

The update of `dart_style` to `^3.0.0` is a breaking change.

Related issue: #950 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
