### PR TITLE
Allow analyzer version under 11.0.0

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.21.1
+  * Allow analyzer `>=6.3.0 <11.0.0`
+
 ## 0.21.0
   * BREAKING CHANGE: Update `dart_style` to `^3.0.0`
   * Allow analyzer `>=6.3.0 <8.0.0`

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ">=6.3.0 <11.0.0"
+  analyzer: "^10.0.0"
   args: ^2.7.0
   dart_style: ^3.1.2
   intl: ^0.20.2

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ">=6.3.0 <11.0.0"
   args: ^2.7.0
   dart_style: ^3.1.2
   intl: ^0.20.2

--- a/pkgs/intl_translation/pubspec.yaml
+++ b/pkgs/intl_translation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_translation
-version: 0.21.0
+version: 0.21.1
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ^8.1.1
+  analyzer: ^10.0.0
   args: ^2.7.0
   dart_style: ^3.1.2
   intl: ^0.20.2


### PR DESCRIPTION
Update analyzer version to accept version under 11.0.0, accepting de facto the latest 10.0.0 version.

- test seems to pass with this version without modification
- tested on one of my project without problem
- 