### PR TITLE
feat(intl4x): add locale.dart entrypoint exposing only Locale

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-alpha.2-wip
+
+- Add `locale.dart` entrypoint exposing only `Locale`.
+
 ## 1.0.0-alpha.1
 
 - Update ICU4X to `2.2.0-dev.2` and other small fixes.

--- a/pkgs/intl4x/lib/locale.dart
+++ b/pkgs/intl4x/lib/locale.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/locale/locale.dart' show Locale;

--- a/pkgs/intl4x/lib/locale.dart
+++ b/pkgs/intl4x/lib/locale.dart
@@ -5,6 +5,7 @@
 /// Support for Unicode locale identifiers.
 ///
 /// Use the [Locale] class to represent and manipulate locales.
+/// @docImport 'locale.dart';
 library;
 
 export 'src/locale/locale.dart' show Locale;

--- a/pkgs/intl4x/lib/locale.dart
+++ b/pkgs/intl4x/lib/locale.dart
@@ -2,4 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Support for Unicode locale identifiers.
+///
+/// Use the [Locale] class to represent and manipulate locales.
+library;
+
 export 'src/locale/locale.dart' show Locale;

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intl4x
 description: >-
   A lightweight modular library for internationalization (i18n) functionality.
-version: 1.0.0-alpha.1
+version: 1.0.0-alpha.2-wip
 repository: https://github.com/dart-lang/i18n/tree/main/pkgs/intl4x
 issue_tracker: https://github.com/dart-lang/i18n/issues?q=is%3Aissue+is%3Aopen+label%3Apackage%3Aintl4x
 


### PR DESCRIPTION
For users wanting only the locale.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
