### PR TITLE
Add new formats for datetime

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0-alpha.3-wip
 
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.
+- Add more `DateTimeFormat`s.
 
 ## 1.0.0-alpha.2
 

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format.dart
@@ -44,6 +44,20 @@ sealed class DateTimeFormat {
     locale ?? findSystemLocale(),
   ).d(alignment: alignment, length: length);
 
+  /// Formatting just the weekday.
+  ///
+  /// Example:
+  /// ```dart
+  /// import 'package:intl4x/datetime_format.dart';
+  ///
+  /// void main() {
+  ///   final date = DateTime(2021, 12, 17, 4, 0, 42);
+  ///   print(DateTimeFormat.weekday().format(date)); // Output: 'Friday'
+  /// }
+  /// ```
+  static DateTimeFormatter weekday({Locale? locale, DateTimeLength? length}) =>
+      DateTimeFormatImpl.build(locale ?? findSystemLocale()).e(length: length);
+
   /// Formatting just the month.
   ///
   /// Example:
@@ -82,6 +96,25 @@ sealed class DateTimeFormat {
     locale ?? findSystemLocale(),
   ).md(alignment: alignment, length: length);
 
+  /// Formatting the month, day, and weekday.
+  ///
+  /// Example:
+  /// ```dart
+  /// import 'package:intl4x/datetime_format.dart';
+  ///
+  /// void main() {
+  ///   final date = DateTime(2021, 12, 17, 4, 0, 42);
+  ///   print(DateTimeFormat.monthDayWeekday().format(date)); // Output: 'Fri, Dec 17'
+  /// }
+  /// ```
+  static DateTimeFormatter monthDayWeekday({
+    Locale? locale,
+    DateTimeAlignment? alignment,
+    DateTimeLength? length,
+  }) => DateTimeFormatImpl.build(
+    locale ?? findSystemLocale(),
+  ).mde(alignment: alignment, length: length);
+
   /// Formatting just the year.
   ///
   /// Example:
@@ -101,6 +134,26 @@ sealed class DateTimeFormat {
   }) => DateTimeFormatImpl.build(
     locale ?? findSystemLocale(),
   ).y(alignment: alignment, length: length, yearStyle: yearStyle);
+
+  /// Formatting the year and month.
+  ///
+  /// Example:
+  /// ```dart
+  /// import 'package:intl4x/datetime_format.dart';
+  ///
+  /// void main() {
+  ///   final date = DateTime(2021, 12, 17, 4, 0, 42);
+  ///   print(DateTimeFormat.yearMonth().format(date)); // Output: 'Dec 2021'
+  /// }
+  /// ```
+  static DateTimeFormatter yearMonth({
+    Locale? locale,
+    DateTimeAlignment? alignment,
+    DateTimeLength? length,
+    YearStyle? yearStyle,
+  }) => DateTimeFormatImpl.build(
+    locale ?? findSystemLocale(),
+  ).ym(alignment: alignment, length: length, yearStyle: yearStyle);
 
   /// Formatting the year, month, and day.
   ///

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -8,7 +8,6 @@ import 'dart:js_interop_unsafe';
 import 'package:collection/collection.dart' show IterableExtension;
 
 import '../locale/locale.dart';
-import '../options.dart';
 import 'datetime_format_impl.dart';
 import 'datetime_format_options.dart';
 
@@ -237,9 +236,17 @@ class _DateTimeFormatECMA extends DateTimeFormatImpl {
       );
 
   @override
+  FormatterImpl e({DateTimeLength? length}) => _FormatterECMA._(
+    this,
+    _DateTimeJSOptions.from(weekday: _weekday(length)),
+    locale,
+  );
+
+  @override
   FormatterStandaloneImpl m({
     DateTimeAlignment? alignment,
     DateTimeLength? length,
+    bool standalone = true,
   }) => _FormatterStandaloneECMA._(
     this,
     _DateTimeJSOptions.from(month: _monthStyle(alignment, length)),
@@ -253,6 +260,18 @@ class _DateTimeFormatECMA extends DateTimeFormatImpl {
         _DateTimeJSOptions.from(
           month: _monthStyle(alignment, length),
           day: _dayStyle(alignment, length),
+        ),
+        locale,
+      );
+
+  @override
+  FormatterImpl mde({DateTimeAlignment? alignment, DateTimeLength? length}) =>
+      _FormatterECMA._(
+        this,
+        _DateTimeJSOptions.from(
+          month: _monthStyle(alignment, length),
+          day: _dayStyle(alignment, length),
+          weekday: _weekday(length),
         ),
         locale,
       );
@@ -283,6 +302,21 @@ class _DateTimeFormatECMA extends DateTimeFormatImpl {
     _DateTimeJSOptions.from(
       year: _yearStyle(length, alignment, yearStyle),
       yearStyle: yearStyle,
+    ),
+    locale,
+  );
+
+  @override
+  FormatterImpl ym({
+    DateTimeAlignment? alignment,
+    DateTimeLength? length,
+    YearStyle? yearStyle,
+  }) => _FormatterECMA._(
+    this,
+    _DateTimeJSOptions.from(
+      year: _yearStyle(length, alignment, yearStyle),
+      yearStyle: yearStyle,
+      month: _monthStyle(alignment, length),
     ),
     locale,
   );

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
@@ -27,6 +27,8 @@ abstract class DateTimeFormatImpl {
 
   FormatterImpl d({DateTimeAlignment? alignment, DateTimeLength? length});
 
+  FormatterImpl e({DateTimeLength? length});
+
   FormatterStandaloneImpl m({
     DateTimeAlignment? alignment,
     DateTimeLength? length,
@@ -34,7 +36,15 @@ abstract class DateTimeFormatImpl {
 
   FormatterImpl md({DateTimeAlignment? alignment, DateTimeLength? length});
 
+  FormatterImpl mde({DateTimeAlignment? alignment, DateTimeLength? length});
+
   FormatterStandaloneImpl y({
+    DateTimeAlignment? alignment,
+    DateTimeLength? length,
+    YearStyle? yearStyle,
+  });
+
+  FormatterImpl ym({
     DateTimeAlignment? alignment,
     DateTimeLength? length,
     YearStyle? yearStyle,

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_options.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export '../options.dart' show Calendar, NumberingSystem;
+export '../options.dart' show Calendar, NumberingSystem, Style;
 
 /// Styles for formatting the year component of a date.
 enum YearStyle {

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/date_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/date_formatter.dart
@@ -50,6 +50,36 @@ class DateFormatterX extends FormatterImpl {
       ),
       super(impl);
 
+  DateFormatterX.e(this.impl, this.localeX, icu.DateTimeLength? length)
+    : formatter = icu.DateFormatter.e(localeX, length),
+      super(impl);
+
+  DateFormatterX.mde(
+    this.impl,
+    this.localeX,
+    icu.DateTimeAlignment? alignment,
+    icu.DateTimeLength? length,
+  ) : formatter = icu.DateFormatter.mde(
+        localeX,
+        alignment: alignment,
+        length: length ?? icu.DateTimeLength.short,
+      ),
+      super(impl);
+
+  DateFormatterX.ym(
+    this.impl,
+    this.localeX,
+    icu.DateTimeAlignment? alignment,
+    icu.DateTimeLength? length,
+    icu.YearStyle? yearStyle,
+  ) : formatter = icu.DateFormatter.ym(
+        localeX,
+        alignment: alignment,
+        length: length ?? icu.DateTimeLength.short,
+        yearStyle: yearStyle,
+      ),
+      super(impl);
+
   DateFormatterX.y(
     this.impl,
     this.localeX,

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/datetime_format_4x.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/datetime_format_4x.dart
@@ -32,6 +32,10 @@ class DateTimeFormat4X extends DateTimeFormatImpl {
       DateFormatterX.d(this, localeX, alignment?.toX, length?.toX);
 
   @override
+  FormatterImpl e({DateTimeLength? length}) =>
+      DateFormatterX.e(this, localeX, length?.toX);
+
+  @override
   FormatterStandaloneImpl m({
     DateTimeAlignment? alignment,
     DateTimeLength? length,
@@ -42,11 +46,28 @@ class DateTimeFormat4X extends DateTimeFormatImpl {
       DateFormatterX.md(this, localeX, alignment?.toX, length?.toX);
 
   @override
+  FormatterImpl mde({DateTimeAlignment? alignment, DateTimeLength? length}) =>
+      DateFormatterX.mde(this, localeX, alignment?.toX, length?.toX);
+
+  @override
   FormatterStandaloneImpl y({
     DateTimeAlignment? alignment,
     DateTimeLength? length,
     YearStyle? yearStyle,
   }) => DateFormatterUX.y(
+    this,
+    localeX,
+    alignment?.toX,
+    length?.toX,
+    yearStyle?.toX,
+  );
+
+  @override
+  FormatterImpl ym({
+    DateTimeAlignment? alignment,
+    DateTimeLength? length,
+    YearStyle? yearStyle,
+  }) => DateFormatterX.ym(
     this,
     localeX,
     alignment?.toX,

--- a/pkgs/intl4x/test/datetime_format_test.dart
+++ b/pkgs/intl4x/test/datetime_format_test.dart
@@ -83,6 +83,37 @@ void main() {
         matches(r'3\sAM'),
       ),
     );
+    testWithFormatting(
+      'e',
+      () => expect(
+        DateTimeFormat.weekday(
+          locale: Locale.parse('en-US'),
+          length: DateTimeLength.long,
+        ).format(dateTime),
+        'Thursday',
+      ),
+    );
+    testWithFormatting(
+      'mde',
+      () => expect(
+        DateTimeFormat.monthDayWeekday(
+          locale: Locale.parse('en-US'),
+          length: DateTimeLength.long,
+        ).format(dateTime),
+        'Thursday, December 20',
+      ),
+    );
+    testWithFormatting(
+      'ym',
+      () => expect(
+        DateTimeFormat.yearMonth(
+          locale: Locale.parse('en-US'),
+          length: DateTimeLength.long,
+          yearStyle: YearStyle.full,
+        ).format(dateTime),
+        'December 2012',
+      ),
+    );
   });
 
   group('timezone ymd', () {


### PR DESCRIPTION
Necessary for Flutter intl->intl4x migration. Also nice to have anyways.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
