### PR TITLE
Add `tryParse` to Locale

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add more `DateTimeFormat`s.
 - Update `PluralRules.select` to select from plural form options.
 - Add doc examples using dartdoc `{@example}` directive.
+- Make `Locale::parse` nullable.
 
 ## 1.0.0-alpha.2
 

--- a/pkgs/intl4x/lib/src/locale/locale.dart
+++ b/pkgs/intl4x/lib/src/locale/locale.dart
@@ -26,6 +26,8 @@ abstract class Locale {
   static Locale? tryParse(String s) {
     try {
       return parse(s);
+    } on Error {
+      rethrow;
     } catch (_) {
       return null;
     }

--- a/pkgs/intl4x/lib/src/locale/locale.dart
+++ b/pkgs/intl4x/lib/src/locale/locale.dart
@@ -26,9 +26,7 @@ abstract class Locale {
   static Locale? tryParse(String s) {
     try {
       return parse(s);
-    } on Error {
-      rethrow;
-    } catch (_) {
+    } on Exception {
       return null;
     }
   }

--- a/pkgs/intl4x/lib/src/locale/locale.dart
+++ b/pkgs/intl4x/lib/src/locale/locale.dart
@@ -21,6 +21,16 @@ abstract class Locale {
   /// Constructs a [Locale] by parsing a BCP47 language tag.
   static Locale parse(String s) => parseLocale(s);
 
+  /// Constructs a [Locale] by parsing a BCP47 language tag, or returns `null`
+  /// if parsing fails.
+  static Locale? tryParse(String s) {
+    try {
+      return parse(s);
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Returns a new `Locale` with the given `calendar`.
   Locale withCalendar(Calendar calendar);
 

--- a/pkgs/intl4x/test/locale_test.dart
+++ b/pkgs/intl4x/test/locale_test.dart
@@ -36,5 +36,18 @@ void main() {
       ).withClockStyle(ClockStyle.oneToTwelve);
       expect(locale.toLanguageTag(), 'en-US-u-hc-h12');
     });
+
+    group('tryParse', () {
+      test('valid locale', () {
+        final locale = Locale.tryParse('en-US');
+        expect(locale, isNotNull);
+        expect(locale?.toLanguageTag(), 'en-US');
+      });
+
+      test('invalid locale', () {
+        final locale = Locale.tryParse('invalid_locale_#@!');
+        expect(locale, isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
Follows the Dart convention of having `parse`/`tryParse` duos.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
