### PR TITLE
Add plural selection logic

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.0-alpha.3-wip
 
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.
-- Add `selectFrom` to plurals.
+- Update `PluralRules.select` to select from plural form options.
 
 ## 1.0.0-alpha.2
 

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0-alpha.3-wip
 
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.
+- Add `selectFrom` to plurals.
 
 ## 1.0.0-alpha.2
 

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -136,7 +136,7 @@ void main() {
 
 ### Plural Rules
 
-Select the correct plural category for a given number based on locale rules (e.g., `one`, `few`, `many`).
+Select the correct plural form for a given number based on locale rules.
 
 ```dart
 import 'package:intl4x/plural_rules.dart';
@@ -147,10 +147,12 @@ void main() {
     type: PluralType.ordinal,
   );
 
-  print(rules.select(1)); // PluralCategory.one (st)
-  print(rules.select(2)); // PluralCategory.two (nd)
-  print(rules.select(3)); // PluralCategory.few (rd)
-  print(rules.select(4)); // PluralCategory.other (th)
+  String numberPlural(int i) => rules.select(i, one: 'st', two: 'nd', few: 'rd', other: 'th');
+
+  print(numberPlural(1)); // 'st'
+  print(numberPlural(2)); // 'nd'
+  print(numberPlural(3)); // 'rd'
+  print(numberPlural(4)); // 'th'
 }
 ```
 

--- a/pkgs/intl4x/lib/plural_rules.dart
+++ b/pkgs/intl4x/lib/plural_rules.dart
@@ -4,8 +4,8 @@
 
 /// The appropriate locale-dependent plural form.
 ///
-/// The [PluralRules] object returns the [PluralCategory] of the input [num]
-/// to [PluralRules.select]. While English only uses 'one' and 'other', other
+/// The [PluralRules] object selects a localized value based on input [num]
+/// using [PluralRules.select]. While English only uses 'one' and 'other', other
 /// languages have more plural forms. For example, Arabic uses 'zero', 'one',
 /// 'two', 'few', 'many', and 'other'.
 ///
@@ -15,14 +15,13 @@
 ///
 /// void main() {
 ///   final rules = PluralRules(locale: Locale.parse('en-US'));
-///   print(rules.select(3)); // prints 'PluralCategory.other'
+///   print(rules.select(3, one: 'item', other: 'items')); // prints 'items'
 /// }
 /// ```
+///@docImport 'src/plural_rules/plural_rules.dart';
 library;
 
-import 'src/plural_rules/plural_rules.dart' show PluralCategory, PluralRules;
-
 export 'src/locale/locale.dart' show Locale;
-export 'src/plural_rules/plural_rules.dart' show PluralCategory, PluralRules;
+export 'src/plural_rules/plural_rules.dart' show PluralRules;
 export 'src/plural_rules/plural_rules_options.dart'
     show Digits, PluralType, RoundingMode, TrailingZeroDisplay;

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
@@ -65,29 +65,20 @@ final class PluralRules {
 
   T selectFrom<T extends Object?>(
     num count, {
-    required Locale locale,
     T? zero,
     T? one,
     T? two,
     T? few,
     T? many,
     required T other,
-  }) {
-    switch (select(count)) {
-      case PluralCategory.zero:
-        return zero ?? other;
-      case PluralCategory.one:
-        return one ?? other;
-      case PluralCategory.two:
-        return two ?? other;
-      case PluralCategory.few:
-        return few ?? other;
-      case PluralCategory.many:
-        return many ?? other;
-      case PluralCategory.other:
-        return other;
-    }
-  }
+  }) => switch (select(count)) {
+    PluralCategory.zero => zero ?? other,
+    PluralCategory.one => one ?? other,
+    PluralCategory.two => two ?? other,
+    PluralCategory.few => few ?? other,
+    PluralCategory.many => many ?? other,
+    PluralCategory.other => other,
+  };
 }
 
 /// Defines the locale-specific grammatical categories for plural forms.

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
@@ -62,6 +62,32 @@ final class PluralRules {
       return _pluralRulesImpl.selectImpl(number);
     }
   }
+
+  T selectFrom<T extends Object?>(
+    num count, {
+    required Locale locale,
+    T? zero,
+    T? one,
+    T? two,
+    T? few,
+    T? many,
+    required T other,
+  }) {
+    switch (select(count)) {
+      case PluralCategory.zero:
+        return zero ?? other;
+      case PluralCategory.one:
+        return one ?? other;
+      case PluralCategory.two:
+        return two ?? other;
+      case PluralCategory.few:
+        return few ?? other;
+      case PluralCategory.many:
+        return many ?? other;
+      case PluralCategory.other:
+        return other;
+    }
+  }
 }
 
 /// Defines the locale-specific grammatical categories for plural forms.

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules.dart
@@ -42,28 +42,18 @@ final class PluralRules {
          ),
        );
 
-  /// Returns the appropriate [PluralCategory] for the given [number].
+  /// Returns the appropriate plural form for [count] among the options.
+  ///
+  /// Evaluates the locale's plural category for [count] and returns the
+  /// corresponding value ([zero], [one], [two], [few], [many]), falling back to
+  /// [other] if that category value is not specified.
   ///
   /// Example for English (`en-US`):
   /// ```dart
-  /// PluralRules(locale: Locale.parse('en-US'))
-  ///   .select(1) == PluralCategory.one
-  /// PluralRules(locale: Locale.parse('en-US'))
-  ///   .select(2) == PluralCategory.other
+  /// rules.select(1, one: 'cat', other: 'cats') // returns 'cat'
+  /// rules.select(2, one: 'cat', other: 'cats') // returns 'cats'
   /// ```
-  /// Example for a language like Polish (`pl`), which has a 'few' category:
-  /// ```dart
-  /// PluralRules(locale: Locale.parse('pl')).select(3) == PluralCategory.few
-  /// ```
-  PluralCategory select(num number) {
-    if (isInTest) {
-      return PluralCategory.other;
-    } else {
-      return _pluralRulesImpl.selectImpl(number);
-    }
-  }
-
-  T selectFrom<T extends Object?>(
+  T select<T extends Object?>(
     num count, {
     T? zero,
     T? one,
@@ -71,15 +61,14 @@ final class PluralRules {
     T? few,
     T? many,
     required T other,
-  }) => switch (select(count)) {
-    PluralCategory.zero => zero ?? other,
-    PluralCategory.one => one ?? other,
-    PluralCategory.two => two ?? other,
-    PluralCategory.few => few ?? other,
-    PluralCategory.many => many ?? other,
-    PluralCategory.other => other,
-  };
+  }) => isInTest
+      ? other
+      : switch (_pluralRulesImpl.selectImpl(count)) {
+          PluralCategory.zero => zero ?? other,
+          PluralCategory.one => one ?? other,
+          PluralCategory.two => two ?? other,
+          PluralCategory.few => few ?? other,
+          PluralCategory.many => many ?? other,
+          PluralCategory.other => other,
+        };
 }
-
-/// Defines the locale-specific grammatical categories for plural forms.
-enum PluralCategory { zero, one, two, few, many, other }

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_4x.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_4x.dart
@@ -5,7 +5,6 @@
 import 'package:icu4x/icu4x.dart' as icu;
 import '../locale/locale.dart';
 import '../locale/locale_4x.dart';
-import 'plural_rules.dart';
 import 'plural_rules_impl.dart';
 import 'plural_rules_options.dart';
 

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_ecma.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_ecma.dart
@@ -5,7 +5,6 @@
 import 'dart:js_interop';
 
 import '../locale/locale.dart';
-import 'plural_rules.dart';
 import 'plural_rules_impl.dart';
 import 'plural_rules_options.dart';
 

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_impl.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_impl.dart
@@ -4,7 +4,6 @@
 
 import '../locale/locale.dart';
 import '../utils.dart';
-import 'plural_rules.dart';
 import 'plural_rules_options.dart';
 import 'plural_rules_stub.dart'
     if (dart.library.js_interop) 'plural_rules_ecma.dart';
@@ -21,3 +20,6 @@ abstract class PluralRulesImpl {
   static PluralRulesImpl build(Locale locales, PluralRulesOptions options) =>
       buildFormatter(locales, options, getPluralSelectECMA, getPluralSelect4X);
 }
+
+/// Defines the locale-specific grammatical categories for plural forms.
+enum PluralCategory { zero, one, two, few, many, other }

--- a/pkgs/intl4x/test/plural_rules_test.dart
+++ b/pkgs/intl4x/test/plural_rules_test.dart
@@ -8,35 +8,53 @@ import 'utils.dart';
 
 void main() {
   testWithFormatting('en-US simple', () {
-    final rules = PluralRules(locale: Locale.parse('en-US'));
+    final s = getRules(PluralRules(locale: Locale.parse('en-US')));
 
-    expect(rules.select(0), PluralCategory.other);
-    expect(rules.select(1), PluralCategory.one);
-    expect(rules.select(2), PluralCategory.other);
-    expect(rules.select(3), PluralCategory.other);
+    expect(s(0), 'other');
+    expect(s(1), 'one');
+    expect(s(2), 'other');
+    expect(s(3), 'other');
   });
 
   testWithFormatting('ar-EG simple', () {
-    final rules = PluralRules(locale: Locale.parse('ar-EG'));
+    final s = getRules(PluralRules(locale: Locale.parse('ar-EG')));
 
-    expect(rules.select(0), PluralCategory.zero);
-    expect(rules.select(1), PluralCategory.one);
-    expect(rules.select(2), PluralCategory.two);
-    expect(rules.select(6), PluralCategory.few);
-    expect(rules.select(18), PluralCategory.many);
+    expect(s(0), 'zero');
+    expect(s(1), 'one');
+    expect(s(2), 'two');
+    expect(s(6), 'few');
+    expect(s(18), 'many');
   });
 
   testWithFormatting('en-US ordinal', () {
-    final rules = PluralRules(
-      locale: Locale.parse('en-US'),
-      type: PluralType.ordinal,
+    final s = getRules(
+      PluralRules(locale: Locale.parse('en-US'), type: PluralType.ordinal),
     );
 
-    expect(rules.select(0), PluralCategory.other);
-    expect(rules.select(1), PluralCategory.one);
-    expect(rules.select(2), PluralCategory.two);
-    expect(rules.select(3), PluralCategory.few);
-    expect(rules.select(4), PluralCategory.other);
-    expect(rules.select(21), PluralCategory.one);
+    expect(s(0), 'other');
+    expect(s(1), 'one');
+    expect(s(2), 'two');
+    expect(s(3), 'few');
+    expect(s(4), 'other');
+    expect(s(21), 'one');
+  });
+
+  testWithFormatting('fallback to other', () {
+    final rules = PluralRules(locale: Locale.parse('ar-EG'));
+
+    expect(rules.select(0, other: 'fallback'), 'fallback');
+    expect(rules.select(1, other: 'fallback'), 'fallback');
+    expect(rules.select(2, other: 'fallback'), 'fallback');
   });
 }
+
+String Function(num n) getRules(PluralRules rules) =>
+    (num n) => rules.select(
+      n,
+      zero: 'zero',
+      one: 'one',
+      two: 'two',
+      few: 'few',
+      many: 'many',
+      other: 'other',
+    );


### PR DESCRIPTION
Seems useful, at least that's how it was mainly used in `package:intl`. We could even remove the `select` entirely in favor of this... Thoughts?

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
