### PR TITLE
Validate locale path in FileDataReader

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.20.3
+ * Validate locale paths in `FileDataReader` to ensure they remain inside the target data directory.
  * Updated the Turkish Lira (TRY) currency symbol in `simpleCurrencySymbols`
    from "TL" to "₺" (U+20BA). This ensures accuracy and alignment with the
    official symbol introduced in 2012.

--- a/pkgs/intl/lib/src/file_data_reader.dart
+++ b/pkgs/intl/lib/src/file_data_reader.dart
@@ -21,7 +21,15 @@ class FileDataReader implements LocaleDataReader {
   /// Read the locale data found for [locale] on our [path].
   @override
   Future<String> read(String locale) {
-    var file = File(join(path, '$locale.json'));
+    var filePath = join(path, '$locale.json');
+    if (!isWithin(path, filePath)) {
+      throw ArgumentError.value(
+        locale,
+        'locale',
+        'Resolves outside the data directory',
+      );
+    }
+    var file = File(filePath);
     return file.readAsString();
   }
 }

--- a/pkgs/intl/test/date_time_format_file_even_test.dart
+++ b/pkgs/intl/test/date_time_format_file_even_test.dart
@@ -16,4 +16,14 @@ import 'date_time_format_test_stub.dart';
 
 void main() {
   runWith(evenLocales, dataDirectory, initializeDateFormatting);
+
+  test(
+    'FileDataReader rejects locale paths resolving outside data directory',
+    () {
+      expect(
+        () => initializeDateFormatting('../../secret', dataDirectory),
+        throwsArgumentError,
+      );
+    },
+  );
 }


### PR DESCRIPTION
Ensure that file paths resolved by FileDataReader remain within the configured base data directory before reading data.