### PR TITLE
Validate locale identifier in generate_from_arb

### DIFF
--- a/pkgs/intl_translation/CHANGELOG.md
+++ b/pkgs/intl_translation/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.22.0
+  * Validate locale identifiers in `generate_from_arb`.
   * Upgrade analyzer to `^12.1.0`.
   * Escape text direction code points in generated code.
   * Upgrade analyzer to `^14.0.0`.

--- a/pkgs/intl_translation/bin/generate_from_arb.dart
+++ b/pkgs/intl_translation/bin/generate_from_arb.dart
@@ -32,6 +32,11 @@ import 'package:path/path.dart' as path;
 
 const jsonDecoder = JsonCodec();
 
+/// Permissive pattern for a Unicode locale identifier (BCP 47 tag with
+/// optional `@` keywords). Used to validate the `@@locale` value read from an
+/// ARB file before it is interpolated into generated Dart source.
+final _validLocale = RegExp(r'^[A-Za-z0-9_@.\-]{1,64}$');
+
 void main(List<String> args) {
   var targetDir = '.';
   var parser = ArgParser();
@@ -249,6 +254,12 @@ void loadData(
     print(
       'No @@locale or _locale field found in $name, '
       "assuming '$locale' based on the file name.",
+    );
+  }
+  if (!_validLocale.hasMatch(locale)) {
+    throw FormatException(
+      'Invalid locale "$locale" in $filename: a locale must contain only '
+      'ASCII letters, digits, and the characters "_", "-", "@", ".".',
     );
   }
   // Remove all metadata from the map

--- a/pkgs/intl_translation/lib/src/messages/message.dart
+++ b/pkgs/intl_translation/lib/src/messages/message.dart
@@ -80,7 +80,7 @@ abstract class Message {
   static final _evaluator = ConstantEvaluator();
 
   static String? _evaluateAsString(Expression expression) {
-    var result = expression.accept2(_evaluator);
+    var result = expression.accept(_evaluator);
     if (result == ConstantEvaluator.NOT_A_CONSTANT || result is! String) {
       return null;
     } else {
@@ -89,7 +89,7 @@ abstract class Message {
   }
 
   static Map? _evaluateAsMap(Expression expression) {
-    var result = expression.accept2(_evaluator);
+    var result = expression.accept(_evaluator);
     if (result == ConstantEvaluator.NOT_A_CONSTANT || result is! Map) {
       return null;
     } else {

--- a/pkgs/intl_translation/lib/visitors/message_finding_visitor.dart
+++ b/pkgs/intl_translation/lib/visitors/message_finding_visitor.dart
@@ -296,7 +296,7 @@ class MessageFindingVisitor extends GeneralizingAstVisitor {
     for (var namedExpr in arguments.whereType<NamedArgument>()) {
       var name = namedExpr.name.lexeme;
       var exp = namedExpr.argumentExpression;
-      var basicValue = exp.accept2(ConstantEvaluator());
+      var basicValue = exp.accept(ConstantEvaluator());
       var value = basicValue == ConstantEvaluator.NOT_A_CONSTANT
           ? exp.toString()
           : basicValue;

--- a/pkgs/intl_translation/test/generate_from_arb_test.dart
+++ b/pkgs/intl_translation/test/generate_from_arb_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  test('generate_from_arb rejects invalid locale names in ARB files', () async {
+    final tempDir = await Directory.systemTemp.createTemp('arb_test');
+    try {
+      final dartFile = File(path.join(tempDir.path, 'main.dart'));
+      await dartFile.writeAsString('void main() {}');
+
+      final arbFile = File(path.join(tempDir.path, 'invalid.arb'));
+      await arbFile.writeAsString('''{
+  "@@locale": "en'\\nfinal pwn = 0xdead;\\nvar q='",
+  "hello": "Hello"
+}''');
+
+      final result = await Process.run(Platform.executable, [
+        path.join('bin', 'generate_from_arb.dart'),
+        dartFile.path,
+        arbFile.path,
+      ], workingDirectory: path.join(Directory.current.path));
+
+      expect(result.exitCode, isNot(0));
+      expect(result.stderr, contains('Invalid locale'));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+}


### PR DESCRIPTION
Validate locale strings read from ARB files to ensure they are well-formed locale identifiers before generating Dart files.