### PR TITLE
ci: verify ICU4X native binary artifact attestations in intl4x workflow

### DIFF
--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -45,6 +45,11 @@ jobs:
 
       - run: dart test
 
+      - name: Verify ICU4X binary artifact attestations
+        run: |
+          find .dart_tool -name "*icu4x*" -type f -exec gh attestation verify {} --owner unicode-org --repo icu4x \;
+        continue-on-error: true
+
       - run: dart test -p chrome
 
       - run: dart --enable-experiment=record-use build cli --target example.dart


### PR DESCRIPTION
### Summary
- Adds a step in `.github/workflows/intl4x.yml` to verify GitHub artifact attestations (`gh attestation verify ... --owner unicode-org --repo icu4x`) for downloaded `icu4x` native FFI library binaries in `.dart_tool/`.
- Uses `continue-on-error: true` initially until the first tagged release with attestations is published on `unicode-org/icu4x`.