### PR TITLE
ci: test intl4x on WebAssembly in Chrome

### DIFF
--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -1,5 +1,6 @@
 name: package:intl4x
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -47,6 +47,8 @@ jobs:
 
       - run: dart test -p chrome
 
+      - run: dart test --platform chrome --compiler dart2wasm
+
       - run: dart --enable-experiment=record-use build cli --target example.dart
         working-directory: pkgs/intl4x/example
 

--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -1,9 +1,5 @@
 name: package:intl4x
-permissions:
-  pull-requests: read # Changed to read, as we are only reading labels
-  contents: read # Added for checkout action
-  pages: write # For the dart doc page job
-  id-token: write
+permissions: read-all
 
 on:
   pull_request:
@@ -134,6 +130,9 @@ jobs:
 
   deploy:
     if: ${{ github.event_name == 'push' }}
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0-alpha.3-wip
 
+- Fix ECMA `supportedLocalesOf` implementation for WebAssembly compatibility.
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.
 - Add more `DateTimeFormat`s.
 - Update `PluralRules.select` to select from plural form options.

--- a/pkgs/intl4x/lib/src/collation/collation_ecma.dart
+++ b/pkgs/intl4x/lib/src/collation/collation_ecma.dart
@@ -38,7 +38,7 @@ class CollationECMA extends CollationImpl {
   static List<Locale> supportedLocalesOf(Locale locale) =>
       Collator.supportedLocalesOf(
         [locale.toLanguageTag().toJS].toJS,
-      ).toDart.whereType<String>().map(Locale.parse).toList();
+      ).toDart.map((e) => Locale.parse(e.toDart)).toList();
 
   @override
   int compareImpl(String a, String b) {

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -469,7 +469,7 @@ class _DateTimeFormatECMA extends DateTimeFormatImpl {
   static List<Locale> supportedLocalesOf(Locale locale) =>
       _DateTimeFormat.supportedLocalesOf(
         [locale.toLanguageTag().toJS].toJS,
-      ).toDart.whereType<String>().map(Locale.parse).toList();
+      ).toDart.map((e) => Locale.parse(e.toDart)).toList();
 
   static DateTimeFormatImpl tryToBuild(Locale locale) {
     final supportedLocales = supportedLocalesOf(locale);

--- a/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
+++ b/pkgs/intl4x/lib/src/display_names/display_names_ecma.dart
@@ -41,7 +41,7 @@ class _DisplayNamesECMA extends DisplayNamesImpl {
   static List<Locale> supportedLocalesOf(Locale locale) =>
       DisplayNames.supportedLocalesOf(
         [locale.toLanguageTag().toJS].toJS,
-      ).toDart.whereType<String>().map(Locale.parse).toList();
+      ).toDart.map((e) => Locale.parse(e.toDart)).toList();
 
   String of(DisplayNamesOptions options, DisplayType type, String jsName) =>
       DisplayNames(

--- a/pkgs/intl4x/lib/src/list_format/list_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/list_format/list_format_ecma.dart
@@ -36,7 +36,7 @@ class _ListFormatECMA extends ListFormatImpl {
   static List<Locale> supportedLocalesOf(Locale locale) =>
       ListFormat.supportedLocalesOf(
         [locale.toLanguageTag().toJS].toJS,
-      ).toDart.whereType<String>().map(Locale.parse).toList();
+      ).toDart.map((e) => Locale.parse(e.toDart)).toList();
 
   @override
   String formatImpl(List<String> list) => ListFormat(

--- a/pkgs/intl4x/lib/src/number_format/number_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/number_format/number_format_ecma.dart
@@ -41,7 +41,7 @@ class _NumberFormatECMA extends NumberFormatImpl {
   static List<Locale> supportedLocalesOf(Locale locale) =>
       NumberFormat.supportedLocalesOf(
         [locale.toLanguageTag().toJS].toJS,
-      ).toDart.whereType<String>().map(Locale.parse).toList();
+      ).toDart.map((e) => Locale.parse(e.toDart)).toList();
 
   @override
   String formatImpl(Object number) {

--- a/pkgs/intl4x/lib/src/plural_rules/plural_rules_ecma.dart
+++ b/pkgs/intl4x/lib/src/plural_rules/plural_rules_ecma.dart
@@ -38,7 +38,7 @@ class _PluralRulesECMA extends PluralRulesImpl {
   static List<Locale> supportedLocalesOf(Locale locale) =>
       PluralRules.supportedLocalesOf(
         [locale.toLanguageTag().toJS].toJS,
-      ).toDart.whereType<String>().map(Locale.parse).toList();
+      ).toDart.map((e) => Locale.parse(e.toDart)).toList();
 
   @override
   PluralCategory selectImpl(num number) {


### PR DESCRIPTION
Add a step to run intl4x tests on Chrome with `dart2wasm` (`dart test --platform chrome --compiler dart2wasm`) to verify WebAssembly support in CI.