### PR TITLE
[intl4x] Expose Locale subtag getters (language, region, script) and equality

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0-alpha.3-wip
 
+- Expose `Locale` subtag getters (`language`, `region`, `script`) and equality.
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.
 - Add more `DateTimeFormat`s.
 - Update `PluralRules.select` to select from plural form options.

--- a/pkgs/intl4x/lib/src/locale/locale.dart
+++ b/pkgs/intl4x/lib/src/locale/locale.dart
@@ -18,36 +18,17 @@ abstract class Locale {
   /// The language subtag (e.g. 'en', 'zh', 'und').
   String get language;
 
-  /// An alias for [language].
-  String get languageCode => language;
-
-  /// The region/country subtag (e.g. 'US', '419'), or null if unspecified.
+  /// The region subtag (e.g. 'US', '419'), or null if unspecified.
   String? get region;
-
-  /// An alias for [region].
-  String? get countryCode => region;
 
   /// The script subtag (e.g. 'Hant', 'Latn'), or null if unspecified.
   String? get script;
-
-  /// An alias for [script].
-  String? get scriptCode => script;
 
   /// Generate a language tag by joining the subtags with the [separator].
   String toLanguageTag([String separator = '-']);
 
   /// Constructs a [Locale] by parsing a BCP47 language tag.
   static Locale parse(String s) => parseLocale(s);
-
-  /// Constructs a [Locale] by parsing a BCP47 language tag, or returns null if
-  /// parsing fails.
-  static Locale? tryParse(String s) {
-    try {
-      return parse(s);
-    } catch (_) {
-      return null;
-    }
-  }
 
   /// Returns a new `Locale` with the given `calendar`.
   Locale withCalendar(Calendar calendar);

--- a/pkgs/intl4x/lib/src/locale/locale.dart
+++ b/pkgs/intl4x/lib/src/locale/locale.dart
@@ -15,11 +15,39 @@ import 'locale_4x.dart' if (dart.library.js_interop) 'locale_ecma.dart';
 /// Examples are `de-DE`, `es-419`, or `zh-Hant-TW`.
 //TODO(mosum): Add RecordUse here somehow to record which locales are used.
 abstract class Locale {
+  /// The language subtag (e.g. 'en', 'zh', 'und').
+  String get language;
+
+  /// An alias for [language].
+  String get languageCode => language;
+
+  /// The region/country subtag (e.g. 'US', '419'), or null if unspecified.
+  String? get region;
+
+  /// An alias for [region].
+  String? get countryCode => region;
+
+  /// The script subtag (e.g. 'Hant', 'Latn'), or null if unspecified.
+  String? get script;
+
+  /// An alias for [script].
+  String? get scriptCode => script;
+
   /// Generate a language tag by joining the subtags with the [separator].
   String toLanguageTag([String separator = '-']);
 
   /// Constructs a [Locale] by parsing a BCP47 language tag.
   static Locale parse(String s) => parseLocale(s);
+
+  /// Constructs a [Locale] by parsing a BCP47 language tag, or returns null if
+  /// parsing fails.
+  static Locale? tryParse(String s) {
+    try {
+      return parse(s);
+    } catch (_) {
+      return null;
+    }
+  }
 
   /// Returns a new `Locale` with the given `calendar`.
   Locale withCalendar(Calendar calendar);
@@ -32,6 +60,14 @@ abstract class Locale {
 
   /// The system's current locale.
   static Locale get system => findSystemLocale();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Locale && toLanguageTag() == other.toLanguageTag());
+
+  @override
+  int get hashCode => toLanguageTag().hashCode;
 
   @override
   String toString() => toLanguageTag();

--- a/pkgs/intl4x/lib/src/locale/locale_4x.dart
+++ b/pkgs/intl4x/lib/src/locale/locale_4x.dart
@@ -19,19 +19,10 @@ class Locale4x implements Locale {
   String get language => _locale.language;
 
   @override
-  String get languageCode => language;
-
-  @override
   String? get region => _locale.region;
 
   @override
-  String? get countryCode => region;
-
-  @override
   String? get script => _locale.script;
-
-  @override
-  String? get scriptCode => script;
 
   @override
   String toLanguageTag([String separator = '-']) => _locale.toString();

--- a/pkgs/intl4x/lib/src/locale/locale_4x.dart
+++ b/pkgs/intl4x/lib/src/locale/locale_4x.dart
@@ -16,7 +16,33 @@ class Locale4x implements Locale {
   icu.Locale get get4X => _locale;
 
   @override
+  String get language => _locale.language;
+
+  @override
+  String get languageCode => language;
+
+  @override
+  String? get region => _locale.region;
+
+  @override
+  String? get countryCode => region;
+
+  @override
+  String? get script => _locale.script;
+
+  @override
+  String? get scriptCode => script;
+
+  @override
   String toLanguageTag([String separator = '-']) => _locale.toString();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Locale && toLanguageTag() == other.toLanguageTag());
+
+  @override
+  int get hashCode => toLanguageTag().hashCode;
 
   @override
   String toString() => toLanguageTag();

--- a/pkgs/intl4x/lib/src/locale/locale_ecma.dart
+++ b/pkgs/intl4x/lib/src/locale/locale_ecma.dart
@@ -27,7 +27,33 @@ class LocaleEcma implements Locale {
   LocaleEcma(this._locale);
 
   @override
+  String get language => _locale.language;
+
+  @override
+  String get languageCode => language;
+
+  @override
+  String? get region => _locale.region;
+
+  @override
+  String? get countryCode => region;
+
+  @override
+  String? get script => _locale.script;
+
+  @override
+  String? get scriptCode => script;
+
+  @override
   String toLanguageTag([String separator = '-']) => _locale.toString();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Locale && toLanguageTag() == other.toLanguageTag());
+
+  @override
+  int get hashCode => toLanguageTag().hashCode;
 
   @override
   String toString() => toLanguageTag();

--- a/pkgs/intl4x/lib/src/locale/locale_ecma.dart
+++ b/pkgs/intl4x/lib/src/locale/locale_ecma.dart
@@ -30,19 +30,10 @@ class LocaleEcma implements Locale {
   String get language => _locale.language;
 
   @override
-  String get languageCode => language;
-
-  @override
   String? get region => _locale.region;
 
   @override
-  String? get countryCode => region;
-
-  @override
   String? get script => _locale.script;
-
-  @override
-  String? get scriptCode => script;
 
   @override
   String toLanguageTag([String separator = '-']) => _locale.toString();

--- a/pkgs/intl4x/test/locale_test.dart
+++ b/pkgs/intl4x/test/locale_test.dart
@@ -40,44 +40,23 @@ void main() {
     test('subtag getters (language, region, script)', () {
       final enUS = Locale.parse('en-US');
       expect(enUS.language, 'en');
-      expect(enUS.languageCode, 'en');
       expect(enUS.region, 'US');
-      expect(enUS.countryCode, 'US');
       expect(enUS.script, isNull);
-      expect(enUS.scriptCode, isNull);
 
       final zhHantTW = Locale.parse('zh-Hant-TW');
       expect(zhHantTW.language, 'zh');
-      expect(zhHantTW.languageCode, 'zh');
       expect(zhHantTW.script, 'Hant');
-      expect(zhHantTW.scriptCode, 'Hant');
       expect(zhHantTW.region, 'TW');
-      expect(zhHantTW.countryCode, 'TW');
 
       final srLatn = Locale.parse('sr-Latn');
       expect(srLatn.language, 'sr');
-      expect(srLatn.languageCode, 'sr');
       expect(srLatn.script, 'Latn');
-      expect(srLatn.scriptCode, 'Latn');
       expect(srLatn.region, isNull);
-      expect(srLatn.countryCode, isNull);
 
       final de = Locale.parse('de');
       expect(de.language, 'de');
-      expect(de.languageCode, 'de');
       expect(de.region, isNull);
-      expect(de.countryCode, isNull);
       expect(de.script, isNull);
-      expect(de.scriptCode, isNull);
-    });
-
-    test('tryParse', () {
-      final valid = Locale.tryParse('en-US');
-      expect(valid, isNotNull);
-      expect(valid!.toLanguageTag(), 'en-US');
-
-      final invalid = Locale.tryParse('invalid!!locale??');
-      expect(invalid, isNull);
     });
 
     test('equality and hashCode', () {

--- a/pkgs/intl4x/test/locale_test.dart
+++ b/pkgs/intl4x/test/locale_test.dart
@@ -36,5 +36,58 @@ void main() {
       ).withClockStyle(ClockStyle.oneToTwelve);
       expect(locale.toLanguageTag(), 'en-US-u-hc-h12');
     });
+
+    test('subtag getters (language, region, script)', () {
+      final enUS = Locale.parse('en-US');
+      expect(enUS.language, 'en');
+      expect(enUS.languageCode, 'en');
+      expect(enUS.region, 'US');
+      expect(enUS.countryCode, 'US');
+      expect(enUS.script, isNull);
+      expect(enUS.scriptCode, isNull);
+
+      final zhHantTW = Locale.parse('zh-Hant-TW');
+      expect(zhHantTW.language, 'zh');
+      expect(zhHantTW.languageCode, 'zh');
+      expect(zhHantTW.script, 'Hant');
+      expect(zhHantTW.scriptCode, 'Hant');
+      expect(zhHantTW.region, 'TW');
+      expect(zhHantTW.countryCode, 'TW');
+
+      final srLatn = Locale.parse('sr-Latn');
+      expect(srLatn.language, 'sr');
+      expect(srLatn.languageCode, 'sr');
+      expect(srLatn.script, 'Latn');
+      expect(srLatn.scriptCode, 'Latn');
+      expect(srLatn.region, isNull);
+      expect(srLatn.countryCode, isNull);
+
+      final de = Locale.parse('de');
+      expect(de.language, 'de');
+      expect(de.languageCode, 'de');
+      expect(de.region, isNull);
+      expect(de.countryCode, isNull);
+      expect(de.script, isNull);
+      expect(de.scriptCode, isNull);
+    });
+
+    test('tryParse', () {
+      final valid = Locale.tryParse('en-US');
+      expect(valid, isNotNull);
+      expect(valid!.toLanguageTag(), 'en-US');
+
+      final invalid = Locale.tryParse('invalid!!locale??');
+      expect(invalid, isNull);
+    });
+
+    test('equality and hashCode', () {
+      final a1 = Locale.parse('en-US');
+      final a2 = Locale.parse('en-US');
+      final b = Locale.parse('en-GB');
+
+      expect(a1, equals(a2));
+      expect(a1.hashCode, equals(a2.hashCode));
+      expect(a1, isNot(equals(b)));
+    });
   });
 }


### PR DESCRIPTION
This PR exposes subtag getters and introspection on `Locale`:

- `language`
- `region`
- `script`
- `operator ==` and `hashCode` based on canonical language tag comparison

Both Native (`Locale4x`) and Web (`LocaleEcma`) implementations are updated with unit tests in `test/locale_test.dart`.