### PR TITLE
Cap the fraction digit scaling factor in NumberFormat

### DIFF
--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.20.4-wip
+ * Fix `NumberFormat` printing unrelated digits for large
+   `maximumFractionDigits` values, fixes issue
+   [#440](https://github.com/dart-lang/i18n/issues/440). Asking for 64 or
+   more digits used to throw `IntegerDivisionByZeroException` where `int`
+   is 64 bits, and no longer does.
+
 ## 0.20.3
  * Updated the Turkish Lira (TRY) currency symbol in `simpleCurrencySymbols`
    from "TL" to "₺" (U+20BA). This ensures accuracy and alignment with the

--- a/pkgs/intl/CHANGELOG.md
+++ b/pkgs/intl/CHANGELOG.md
@@ -3,7 +3,8 @@
    `maximumFractionDigits` values, fixes issue
    [#440](https://github.com/dart-lang/i18n/issues/440). Asking for 64 or
    more digits used to throw `IntegerDivisionByZeroException` where `int`
-   is 64 bits, and no longer does.
+   is 64 bits, and no longer does. On the web, this can change the output for
+   requests with 19 or 20 fraction digits compared with 0.20.3.
 
 ## 0.20.3
  * Updated the Turkish Lira (TRY) currency symbol in `simpleCurrencySymbols`

--- a/pkgs/intl/lib/src/intl/number_format.dart
+++ b/pkgs/intl/lib/src/intl/number_format.dart
@@ -633,6 +633,17 @@ class NumberFormat {
   static final _maxInt = 1 is double ? pow(2, 52) : 1.0e300.floor();
   static final _maxDigits = (log(_maxInt) / log(10)).ceil();
 
+  /// The largest `n` for which `pow(10, n)` still works as a scaling factor.
+  ///
+  /// Where `int` is 64 bits, which includes dart2wasm as well as the VM,
+  /// `pow(10, 19)` wraps around to a negative number, so 18 is the last one
+  /// that fits. Where `int` is a double, as under dart2js, nothing wraps, but
+  /// `toString` switches to exponent notation at 10^21 and those characters
+  /// end up in the digits we print, so 20 is the last usable one. Both caps
+  /// sit right below where the old factor broke, which keeps every result
+  /// that was already well formed byte for byte the same.
+  static final _maxScalingDigits = 1 is double ? 20 : 18;
+
   /// Helpers to check numbers that don't conform to the [num] interface,
   /// e.g. Int64
   bool _isInfinite(dynamic number) => number is num ? number.isInfinite : false;
@@ -725,6 +736,9 @@ class NumberFormat {
 
     var power = 0;
     int digitMultiplier;
+    // Fraction digits we did not scale by because [power] would have run past
+    // what the platform integer holds. They are printed as trailing zeros.
+    var excessFractionDigits = 0;
 
     if (_isInfinite(number)) {
       integerPart = number.toInt();
@@ -808,7 +822,17 @@ class NumberFormat {
 
       computeFractionDigits();
 
-      power = pow(10, fractionDigits) as int;
+      // The scaling factor is 10^fractionDigits times the percent multiplier,
+      // and once fractionDigits gets large that stops being a usable integer,
+      // which used to turn the whole result into garbage. Scale by as much as
+      // fits and print the rest as zeros - a double holds no information out
+      // that far anyway.
+      var scalingDigits = min(
+        fractionDigits,
+        _maxScalingDigits - _multiplierDigits,
+      );
+      excessFractionDigits = fractionDigits - scalingDigits;
+      power = pow(10, scalingDigits) as int;
       digitMultiplier = power * multiplier;
 
       // Multiply out to the number of decimal places and the percent, then
@@ -860,7 +884,10 @@ class NumberFormat {
 
     _decimalSeparator(fractionPresent);
     if (fractionPresent) {
-      _formatFractionPart((fractionPart + power).toString(), minFractionDigits);
+      _formatFractionPart(
+        '${fractionPart + power}${'0' * excessFractionDigits}',
+        minFractionDigits,
+      );
     }
   }
 

--- a/pkgs/intl/lib/src/intl/number_format.dart
+++ b/pkgs/intl/lib/src/intl/number_format.dart
@@ -633,16 +633,11 @@ class NumberFormat {
   static final _maxInt = 1 is double ? pow(2, 52) : 1.0e300.floor();
   static final _maxDigits = (log(_maxInt) / log(10)).ceil();
 
-  /// The largest `n` for which `pow(10, n)` still works as a scaling factor.
+  /// The largest `n` used in `pow(10, n)` for a scaling factor.
   ///
-  /// Where `int` is 64 bits, which includes dart2wasm as well as the VM,
-  /// `pow(10, 19)` wraps around to a negative number, so 18 is the last one
-  /// that fits. Where `int` is a double, as under dart2js, nothing wraps, but
-  /// `toString` switches to exponent notation at 10^21 and those characters
-  /// end up in the digits we print, so 20 is the last usable one. Both caps
-  /// sit right below where the old factor broke, which keeps every result
-  /// that was already well formed byte for byte the same.
-  static final _maxScalingDigits = 1 is double ? 20 : 18;
+  /// `pow(10, 19)` overflows a 64-bit integer, so 18 is the largest value that
+  /// works on every platform.
+  static const _maxScalingDigits = 18;
 
   /// Helpers to check numbers that don't conform to the [num] interface,
   /// e.g. Int64

--- a/pkgs/intl/pubspec.yaml
+++ b/pkgs/intl/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl
-version: 0.20.3 # This should follow semver to not break Flutter, where it is unpinned, see https://github.com/flutter/flutter/blob/main/pubspec.yaml
+version: 0.20.4-wip # This should follow semver to not break Flutter, where it is unpinned, see https://github.com/flutter/flutter/blob/main/pubspec.yaml
 description: >-
   Contains code to deal with internationalized/localized messages, date and
   number formatting and parsing, bi-directional text, and other

--- a/pkgs/intl/test/number_format_test_core.dart
+++ b/pkgs/intl/test/number_format_test_core.dart
@@ -195,6 +195,40 @@ void runTests(Map<String, num> allTestNumbers) {
     }
   });
 
+  test('More fraction digits than the scaling factor can hold', () {
+    // Scaling by 10^fractionDigits used to run past what the platform integer
+    // holds, so the digits printed were whatever the broken factor produced.
+    // 19 is where a 64 bit int wraps and 21 is where a double turns into
+    // exponent notation. https://github.com/dart-lang/i18n/issues/440
+    for (var digits in [19, 20, 21, 25, 40, 100]) {
+      var f = NumberFormat.decimalPattern('en_US')
+        ..minimumFractionDigits = digits
+        ..maximumFractionDigits = digits;
+      expect(
+        f.format(0.1),
+        '0.${'1'.padRight(digits, '0')}',
+        reason: 'fractionDigits: $digits',
+      );
+      expect(
+        f.format(-123.5),
+        '-123.${'5'.padRight(digits, '0')}',
+        reason: 'fractionDigits: $digits',
+      );
+    }
+
+    // A pattern with more '#' than the scaling factor can hold, which is how
+    // the issue was originally reported.
+    expect(NumberFormat('#.${'#' * 40}', 'en_US').format(1), '1');
+
+    // The percent multiplier is folded into the scaling factor, so it eats
+    // into the digits available for scaling. A 64 bit int wraps two digits
+    // earlier here than it does above.
+    var percent = NumberFormat.percentPattern('en_US')
+      ..minimumFractionDigits = 17
+      ..maximumFractionDigits = 17;
+    expect(percent.format(0.001), '0.${'1'.padRight(17, '0')}%');
+  });
+
   test('Exponential form', () {
     var f = NumberFormat('#.###E0');
     for (var x in testExponential.keys) {

--- a/pkgs/intl/test/number_format_test_core.dart
+++ b/pkgs/intl/test/number_format_test_core.dart
@@ -216,15 +216,6 @@ void runTests(Map<String, num> allTestNumbers) {
       );
     }
 
-    var scalingBoundary = NumberFormat.decimalPattern('en_US')
-      ..minimumFractionDigits = 18
-      ..maximumFractionDigits = 18;
-    expect(
-      scalingBoundary.format(1.2345678901234567),
-      1 is double ? '1.234567890123456800' : '1.234567890123456704',
-      reason: 'The eighteenth scaling digit must be used',
-    );
-
     // A pattern with more '#' than the scaling factor can hold, which is how
     // the issue was originally reported.
     expect(NumberFormat('#.${'#' * 40}', 'en_US').format(1), '1');

--- a/pkgs/intl/test/number_format_test_core.dart
+++ b/pkgs/intl/test/number_format_test_core.dart
@@ -216,6 +216,15 @@ void runTests(Map<String, num> allTestNumbers) {
       );
     }
 
+    var scalingBoundary = NumberFormat.decimalPattern('en_US')
+      ..minimumFractionDigits = 18
+      ..maximumFractionDigits = 18;
+    expect(
+      scalingBoundary.format(1.2345678901234567),
+      1 is double ? '1.234567890123456800' : '1.234567890123456704',
+      reason: 'The eighteenth scaling digit must be used',
+    );
+
     // A pattern with more '#' than the scaling factor can hold, which is how
     // the issue was originally reported.
     expect(NumberFormat('#.${'#' * 40}', 'en_US').format(1), '1');


### PR DESCRIPTION
Requesting a large number of fraction digits from `NumberFormat` overflows the integer scaling factor that `format` multiplies the fraction by. The overflow used to fill the fraction with unrelated digits. From 64 digits up there was no output at all, just an integer division error on the VM and dart2wasm. This change caps the scaling factor at 10^18, the largest power of ten that fits a 64-bit `int`, and prints the remaining places as zeros. I kept the same cap where `int` is a double and the factor could have gone two digits further, so a 19 or 20 digit request there can come out differently.

Fixes #440
