### PR TITLE
[intl4x] Implement DateTime range formatting and update icu4x to 2.3.1

### DIFF
--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
-          sdk: stable
+          sdk: dev
 
       - run: dart pub get --example
 
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
-          sdk: stable
+          sdk: dev
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
-          sdk: main
+          sdk: stable
 
       - run: dart pub get --example
 
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
-          sdk: main
+          sdk: stable
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/intl4x.yml
+++ b/.github/workflows/intl4x.yml
@@ -46,7 +46,7 @@ jobs:
 
       - run: dart test --platform chrome --compiler dart2wasm
 
-      - run: dart --enable-experiment=record-use build cli --target example.dart
+      - run: dart build cli --target example.dart
         working-directory: pkgs/intl4x/example
 
       - run: tree . -a

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0-alpha.3-wip
 
+- Update `package:icu4x` to `2.3.1`.
 - Fix ECMA `supportedLocalesOf` implementation for WebAssembly compatibility.
 - Expose `Locale` subtag getters (`language`, `region`, `script`) and equality.
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix ECMA `supportedLocalesOf` implementation for WebAssembly compatibility.
 - Expose `Locale` subtag getters (`language`, `region`, `script`) and equality.
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.
+- Add `formatRange` method to `DateTimeFormat`.
 - Add more `DateTimeFormat`s.
 - Update `PluralRules.select` to select from plural form options.
 - Add doc examples using dartdoc `{@example}` directive.

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -11,13 +11,13 @@ A lightweight, modular library for internationalization (i18n) in Dart, providin
 * Display names.
 * Plural rules.
 
-## Status - experimental
+## Status - preview
 
-We're actively iterating on the API for this package. Please provide feedback via our [issue tracker](https://github.com/dart-lang/i18n/issues).
+This package has now moved from experimental to preview. We will not ship any breaking changes, but are still iterating on some components.
+Please provide feedback via our [issue tracker](https://github.com/dart-lang/i18n/issues)!
 
-This package currently increases binary size in non-web builds significantly. To remedy, compile your app the experimental flag `record-use`
 ```bash
-dart --enable-experiment=record-use build cli --target my-binary-name.dart
+dart build cli --target my-binary-name.dart
 ```
 
 

--- a/pkgs/intl4x/README.md
+++ b/pkgs/intl4x/README.md
@@ -11,13 +11,13 @@ A lightweight, modular library for internationalization (i18n) in Dart, providin
 * Display names.
 * Plural rules.
 
-## Status - preview
+## Status - experimental
 
-This package has now moved from experimental to preview. We will not ship any breaking changes, but are still iterating on some components.
-Please provide feedback via our [issue tracker](https://github.com/dart-lang/i18n/issues)!
+We're actively iterating on the API for this package. Please provide feedback via our [issue tracker](https://github.com/dart-lang/i18n/issues).
 
+This package currently increases binary size in non-web builds significantly. To remedy, compile your app the experimental flag `record-use`
 ```bash
-dart build cli --target my-binary-name.dart
+dart --enable-experiment=record-use build cli --target my-binary-name.dart
 ```
 
 

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_ecma.dart
@@ -123,6 +123,10 @@ class _FormatterStandaloneECMA extends FormatterStandaloneImpl {
   @override
   String formatInternal(DateTime datetime) =>
       dateTimeFormat.format(datetime.js);
+
+  @override
+  String formatRangeInternal(DateTime start, DateTime end) =>
+      dateTimeFormat.formatRange(start.js, end.js);
 }
 
 class _FormatterECMA extends FormatterImpl {
@@ -141,6 +145,10 @@ class _FormatterECMA extends FormatterImpl {
   @override
   String formatInternal(DateTime datetime) =>
       dateTimeFormat.format(datetime.js);
+
+  @override
+  String formatRangeInternal(DateTime start, DateTime end) =>
+      dateTimeFormat.formatRange(start.js, end.js);
 
   @override
   ZonedDateTimeFormatter withTimeZoneLong() =>
@@ -530,6 +538,7 @@ extension type _DateTimeFormat._(JSObject _) implements JSObject {
     _DateTimeJSOptions options,
   ]);
   external String format(Date num);
+  external String formatRange(Date startDate, Date endDate);
 
   external static JSArray<JSString> supportedLocalesOf(JSArray listOfLocales);
 

--- a/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/datetime_format_impl.dart
@@ -96,12 +96,23 @@ abstract class FormatterStandaloneImpl extends DateTimeFormatterStandalone {
 
   String formatInternal(DateTime datetime);
 
+  String formatRangeInternal(DateTime start, DateTime end);
+
   @override
   String format(DateTime datetime) {
     if (isInTest) {
       return '$datetime//${_impl.locale}';
     } else {
       return formatInternal(datetime);
+    }
+  }
+
+  @override
+  String formatRange(DateTime start, DateTime end) {
+    if (isInTest) {
+      return '$start//$end//${_impl.locale}';
+    } else {
+      return formatRangeInternal(start, end);
     }
   }
 }
@@ -147,6 +158,10 @@ sealed class DateTimeFormatterStandalone {
   /// Formats the given [datetime] into a string according to the formatter's
   /// configured locale and options.
   String format(DateTime datetime);
+
+  /// Formats the given date range from [start] to [end] into a string according
+  /// to the formatter's configured locale and options.
+  String formatRange(DateTime start, DateTime end);
 }
 
 /// Formatters that can format a [DateTime] with time zone information.

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/date_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/date_formatter.dart
@@ -11,6 +11,7 @@ import 'datetime_format_4x.dart';
 /// Wraps an [icu.DateFormatter]
 class DateFormatterX extends FormatterImpl {
   final icu.DateFormatter formatter;
+  final icu.DateRangeFormatterGregorian rangeFormatter;
   final DateTimeFormatImpl impl;
   final icu.Locale localeX;
 
@@ -24,6 +25,11 @@ class DateFormatterX extends FormatterImpl {
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
       ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.d(
+        localeX,
+        alignment: alignment,
+        length: length,
+      ),
       super(impl);
 
   DateFormatterX.m(
@@ -35,6 +41,11 @@ class DateFormatterX extends FormatterImpl {
         localeX,
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
+      ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.m(
+        localeX,
+        alignment: alignment,
+        length: length,
       ),
       super(impl);
 
@@ -48,10 +59,16 @@ class DateFormatterX extends FormatterImpl {
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
       ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.md(
+        localeX,
+        alignment: alignment,
+        length: length,
+      ),
       super(impl);
 
   DateFormatterX.e(this.impl, this.localeX, icu.DateTimeLength? length)
     : formatter = icu.DateFormatter.e(localeX, length),
+      rangeFormatter = icu.DateRangeFormatterGregorian.e(localeX, length),
       super(impl);
 
   DateFormatterX.mde(
@@ -63,6 +80,11 @@ class DateFormatterX extends FormatterImpl {
         localeX,
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
+      ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.mde(
+        localeX,
+        alignment: alignment,
+        length: length,
       ),
       super(impl);
 
@@ -76,6 +98,12 @@ class DateFormatterX extends FormatterImpl {
         localeX,
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
+        yearStyle: yearStyle,
+      ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.ym(
+        localeX,
+        alignment: alignment,
+        length: length,
         yearStyle: yearStyle,
       ),
       super(impl);
@@ -92,6 +120,12 @@ class DateFormatterX extends FormatterImpl {
         length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.y(
+        localeX,
+        alignment: alignment,
+        length: length,
+        yearStyle: yearStyle,
+      ),
       super(impl);
 
   DateFormatterX.ymd(
@@ -104,6 +138,12 @@ class DateFormatterX extends FormatterImpl {
         localeX,
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
+        yearStyle: yearStyle,
+      ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.ymd(
+        localeX,
+        alignment: alignment,
+        length: length,
         yearStyle: yearStyle,
       ),
       super(impl);
@@ -120,11 +160,21 @@ class DateFormatterX extends FormatterImpl {
         length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.ymde(
+        localeX,
+        alignment: alignment,
+        length: length,
+        yearStyle: yearStyle,
+      ),
       super(impl);
 
   @override
   String formatInternal(DateTime datetime) =>
       formatter.formatIso(datetime.toX.$1);
+
+  @override
+  String formatRangeInternal(DateTime start, DateTime end) =>
+      rangeFormatter.formatIso(start.toX.$1, end.toX.$1);
 
   @override
   ZonedDateTimeFormatter withTimeZoneShort() => DateFormatterZonedX.short(this);
@@ -152,6 +202,7 @@ class DateFormatterX extends FormatterImpl {
 /// Wraps an [icu.DateFormatter]
 class DateFormatterUX extends FormatterStandaloneImpl {
   final icu.DateFormatter formatter;
+  final icu.DateRangeFormatterGregorian rangeFormatter;
   final DateTimeFormatImpl impl;
   final icu.Locale localeX;
 
@@ -164,6 +215,11 @@ class DateFormatterUX extends FormatterStandaloneImpl {
         localeX,
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
+      ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.m(
+        localeX,
+        alignment: alignment,
+        length: length,
       ),
       super(impl);
 
@@ -179,11 +235,21 @@ class DateFormatterUX extends FormatterStandaloneImpl {
         length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
+      rangeFormatter = icu.DateRangeFormatterGregorian.y(
+        localeX,
+        alignment: alignment,
+        length: length,
+        yearStyle: yearStyle,
+      ),
       super(impl);
 
   @override
   String formatInternal(DateTime datetime) =>
       formatter.formatIso(datetime.toX.$1);
+
+  @override
+  String formatRangeInternal(DateTime start, DateTime end) =>
+      rangeFormatter.formatIso(start.toX.$1, end.toX.$1);
 }
 
 /// Wraps an [icu.ZonedDateFormatter]

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/date_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/date_formatter.dart
@@ -28,7 +28,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.d(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
       ),
       super(impl);
 
@@ -45,7 +45,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.m(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
       ),
       super(impl);
 
@@ -62,7 +62,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.md(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
       ),
       super(impl);
 
@@ -84,7 +84,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.mde(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
       ),
       super(impl);
 
@@ -103,7 +103,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.ym(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
       super(impl);
@@ -123,7 +123,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.y(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
       super(impl);
@@ -143,7 +143,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.ymd(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
       super(impl);
@@ -163,7 +163,7 @@ class DateFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.ymde(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
       super(impl);
@@ -219,7 +219,7 @@ class DateFormatterUX extends FormatterStandaloneImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.m(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
       ),
       super(impl);
 
@@ -238,7 +238,7 @@ class DateFormatterUX extends FormatterStandaloneImpl {
       rangeFormatter = icu.DateRangeFormatterGregorian.y(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         yearStyle: yearStyle,
       ),
       super(impl);

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/date_time_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/date_time_formatter.dart
@@ -30,7 +30,7 @@ class DateTimeFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateTimeRangeFormatterGregorian.mdt(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         timePrecision: timePrecision,
       ),
       super(impl);
@@ -52,7 +52,7 @@ class DateTimeFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateTimeRangeFormatterGregorian.ymdt(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         timePrecision: timePrecision,
         yearStyle: yearStyle,
       ),
@@ -75,7 +75,7 @@ class DateTimeFormatterX extends FormatterImpl {
       rangeFormatter = icu.DateTimeRangeFormatterGregorian.ymdet(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         timePrecision: timePrecision,
         yearStyle: yearStyle,
       ),

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/date_time_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/date_time_formatter.dart
@@ -11,6 +11,7 @@ import 'datetime_format_4x.dart';
 /// Wraps an [icu.DateTimeFormatter]
 class DateTimeFormatterX extends FormatterImpl {
   final icu.DateTimeFormatter formatter;
+  final icu.DateTimeRangeFormatterGregorian rangeFormatter;
   final DateTimeFormatImpl impl;
   final icu.Locale localeX;
 
@@ -26,6 +27,12 @@ class DateTimeFormatterX extends FormatterImpl {
         length: length ?? icu.DateTimeLength.short,
         timePrecision: timePrecision,
       ),
+      rangeFormatter = icu.DateTimeRangeFormatterGregorian.mdt(
+        localeX,
+        alignment: alignment,
+        length: length,
+        timePrecision: timePrecision,
+      ),
       super(impl);
 
   DateTimeFormatterX.ymdt(
@@ -39,6 +46,13 @@ class DateTimeFormatterX extends FormatterImpl {
         localeX,
         alignment: alignment,
         length: length ?? icu.DateTimeLength.short,
+        timePrecision: timePrecision,
+        yearStyle: yearStyle,
+      ),
+      rangeFormatter = icu.DateTimeRangeFormatterGregorian.ymdt(
+        localeX,
+        alignment: alignment,
+        length: length,
         timePrecision: timePrecision,
         yearStyle: yearStyle,
       ),
@@ -58,12 +72,31 @@ class DateTimeFormatterX extends FormatterImpl {
         timePrecision: timePrecision,
         yearStyle: yearStyle,
       ),
+      rangeFormatter = icu.DateTimeRangeFormatterGregorian.ymdet(
+        localeX,
+        alignment: alignment,
+        length: length,
+        timePrecision: timePrecision,
+        yearStyle: yearStyle,
+      ),
       super(impl);
 
   @override
   String formatInternal(DateTime datetime) {
     final (isoDate, time) = datetime.toX;
     return formatter.formatIso(isoDate, time);
+  }
+
+  @override
+  String formatRangeInternal(DateTime start, DateTime end) {
+    final (startIsoDate, startTime) = start.toX;
+    final (endIsoDate, endTime) = end.toX;
+    return rangeFormatter.formatIso(
+      startIsoDate,
+      startTime,
+      endIsoDate,
+      endTime,
+    );
   }
 
   @override

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/time_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/time_formatter.dart
@@ -10,6 +10,7 @@ import 'datetime_format_4x.dart';
 
 class TimeFormatterX extends FormatterImpl {
   final icu.TimeFormatter formatter;
+  final icu.TimeRangeFormatter rangeFormatter;
   final DateTimeFormatImpl impl;
   final icu.Locale localeX;
 
@@ -29,12 +30,25 @@ class TimeFormatterX extends FormatterImpl {
         length: length ?? icu.DateTimeLength.short,
         timePrecision: timePrecision,
       ),
+      rangeFormatter = icu.TimeRangeFormatter(
+        localeX,
+        alignment: alignment,
+        length: length,
+        timePrecision: timePrecision,
+      ),
       super(impl);
 
   @override
   String formatInternal(DateTime datetime) {
     final (_, time) = datetime.toX;
     return formatter.format(time);
+  }
+
+  @override
+  String formatRangeInternal(DateTime start, DateTime end) {
+    final (_, startTime) = start.toX;
+    final (_, endTime) = end.toX;
+    return rangeFormatter.format(startTime, endTime);
   }
 
   @override

--- a/pkgs/intl4x/lib/src/datetime_format/icu4x/time_formatter.dart
+++ b/pkgs/intl4x/lib/src/datetime_format/icu4x/time_formatter.dart
@@ -33,7 +33,7 @@ class TimeFormatterX extends FormatterImpl {
       rangeFormatter = icu.TimeRangeFormatter(
         localeX,
         alignment: alignment,
-        length: length,
+        length: length ?? icu.DateTimeLength.short,
         timePrecision: timePrecision,
       ),
       super(impl);

--- a/pkgs/intl4x/pubspec.yaml
+++ b/pkgs/intl4x/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  icu4x: ^2.2.0-dev.3
+  icu4x: ^2.3.1
   timezone: ^0.11.0
 
 dev_dependencies:

--- a/pkgs/intl4x/test/datetime_format_test.dart
+++ b/pkgs/intl4x/test/datetime_format_test.dart
@@ -608,19 +608,7 @@ void main() {
     final enUS = Locale.parse('en-US');
 
     testWithFormatting(
-      'yearMonthDay range ICU4X',
-      () => expect(
-        DateTimeFormat.yearMonthDay(
-          locale: enUS,
-          yearStyle: YearStyle.full,
-        ).formatRange(start, end),
-        matches(r'Jan 10\s–\s20,\s2023'),
-      ),
-      testOn: 'vm',
-    );
-
-    testWithFormatting(
-      'yearMonthDay range ECMA',
+      'yearMonthDay range',
       () => expect(
         DateTimeFormat.yearMonthDay(
           locale: enUS,
@@ -628,25 +616,25 @@ void main() {
         ).formatRange(start, end),
         matches(r'1/10/2023\s–\s1/20/2023'),
       ),
-      testOn: 'js || wasm',
     );
 
     testWithFormatting(
-      'monthDay range ICU4X',
-      () => expect(
-        DateTimeFormat.monthDay(locale: enUS).formatRange(start, end),
-        matches(r'Jan 10\s–\s20'),
-      ),
-      testOn: 'vm',
-    );
-
-    testWithFormatting(
-      'monthDay range ECMA',
+      'monthDay range',
       () => expect(
         DateTimeFormat.monthDay(locale: enUS).formatRange(start, end),
         matches(r'1/10\s–\s1/20'),
       ),
-      testOn: 'js || wasm',
+    );
+
+    testWithFormatting(
+      'monthDay range with medium length',
+      () => expect(
+        DateTimeFormat.monthDay(
+          locale: enUS,
+          length: DateTimeLength.medium,
+        ).formatRange(start, end),
+        matches(r'Jan 10\s–\s20'),
+      ),
     );
 
     testWithFormatting('time range on same day', () {

--- a/pkgs/intl4x/test/datetime_format_test.dart
+++ b/pkgs/intl4x/test/datetime_format_test.dart
@@ -601,4 +601,77 @@ void main() {
       );
     });
   });
+
+  group('formatRange', () {
+    final start = DateTime(2023, 1, 10, 10, 0);
+    final end = DateTime(2023, 1, 20, 16, 30);
+    final enUS = Locale.parse('en-US');
+
+    testWithFormatting(
+      'yearMonthDay range ICU4X',
+      () => expect(
+        DateTimeFormat.yearMonthDay(
+          locale: enUS,
+          yearStyle: YearStyle.full,
+        ).formatRange(start, end),
+        matches(r'Jan 10\s–\s20,\s2023'),
+      ),
+      testOn: 'vm',
+    );
+
+    testWithFormatting(
+      'yearMonthDay range ECMA',
+      () => expect(
+        DateTimeFormat.yearMonthDay(
+          locale: enUS,
+          yearStyle: YearStyle.full,
+        ).formatRange(start, end),
+        matches(r'1/10/2023\s–\s1/20/2023'),
+      ),
+      testOn: 'js || wasm',
+    );
+
+    testWithFormatting(
+      'monthDay range ICU4X',
+      () => expect(
+        DateTimeFormat.monthDay(locale: enUS).formatRange(start, end),
+        matches(r'Jan 10\s–\s20'),
+      ),
+      testOn: 'vm',
+    );
+
+    testWithFormatting(
+      'monthDay range ECMA',
+      () => expect(
+        DateTimeFormat.monthDay(locale: enUS).formatRange(start, end),
+        matches(r'1/10\s–\s1/20'),
+      ),
+      testOn: 'js || wasm',
+    );
+
+    testWithFormatting('time range on same day', () {
+      final sameDayEnd = DateTime(2023, 1, 10, 16, 30);
+      final formatter = DateTimeFormat.time(
+        locale: enUS,
+        timePrecision: TimePrecision.minute,
+      );
+      expect(
+        formatter.formatRange(start, sameDayEnd),
+        matches(r'10:00\sAM\s–\s4:30\sPM'),
+      );
+    });
+
+    testWithFormatting('year range', () {
+      final startYear = DateTime(2020, 1, 1);
+      final endYear = DateTime(2025, 1, 1);
+      final formatter = DateTimeFormat.year(
+        locale: enUS,
+        yearStyle: YearStyle.full,
+      );
+      expect(
+        formatter.formatRange(startYear, endYear),
+        matches(r'2020\s–\s2025'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
Implement DateTime range formatting in `package:intl4x` and update `package:icu4x` dependency to 2.3.1.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.