### PR TITLE
[intl4x] Add maximize, minimize, and canonicalize to Locale

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0-alpha.3-wip
 
 - Update `package:icu4x` to `2.3.1`.
+- Add `Locale.maximize`, `Locale.minimize`, and `Locale.canonicalize` methods.
 - Fix ECMA `supportedLocalesOf` implementation for WebAssembly compatibility.
 - Expose `Locale` subtag getters (`language`, `region`, `script`) and equality.
 - Add `calendar.dart` entrypoint exposing `Calendar` and `Weekday` with `Weekday.firstDayOfWeek` API.

--- a/pkgs/intl4x/lib/src/locale/locale.dart
+++ b/pkgs/intl4x/lib/src/locale/locale.dart
@@ -24,6 +24,25 @@ abstract class Locale {
   /// The script subtag (e.g. 'Hant', 'Latn'), or null if unspecified.
   String? get script;
 
+  /// Returns a new [Locale] with the most likely language, script, and region
+  /// subtags added based on CLDR likely subtags data.
+  ///
+  /// For example, `en` becomes `en-Latn-US`, `zh` becomes `zh-Hans-CN`, and
+  /// `sr` becomes `sr-Cyrl-RS`.
+  Locale maximize();
+
+  /// Returns a new [Locale] with subtags removed if they match the likely
+  /// subtags that would be added by [maximize].
+  ///
+  /// For example, `en-Latn-US` becomes `en`, and `zh-Hant-TW` becomes `zh-TW`.
+  Locale minimize();
+
+  /// Returns a new [Locale] in canonical BCP47 form.
+  ///
+  /// Replaces deprecated subtags with their preferred values (e.g. `in` ->
+  /// `id`, `iw` -> `he`, `mo` -> `ro`) and normalizes extensions.
+  Locale canonicalize();
+
   /// Generate a language tag by joining the subtags with the [separator].
   String toLanguageTag([String separator = '-']);
 

--- a/pkgs/intl4x/lib/src/locale/locale_4x.dart
+++ b/pkgs/intl4x/lib/src/locale/locale_4x.dart
@@ -25,6 +25,27 @@ class Locale4x implements Locale {
   String? get script => _locale.script;
 
   @override
+  Locale maximize() {
+    final copy = _locale.clone();
+    _expander.maximize(copy);
+    return Locale4x(copy);
+  }
+
+  @override
+  Locale minimize() {
+    final copy = _locale.clone();
+    _expander.minimize(copy);
+    return Locale4x(copy);
+  }
+
+  @override
+  Locale canonicalize() {
+    final copy = _locale.clone();
+    _canonicalizer.canonicalize(copy);
+    return Locale4x(copy);
+  }
+
+  @override
   String toLanguageTag([String separator = '-']) => _locale.toString();
 
   @override
@@ -54,3 +75,7 @@ class Locale4x implements Locale {
 }
 
 Locale parseLocale(String s) => Locale4x(icu.Locale.fromString(s));
+
+final icu.LocaleExpander _expander = icu.LocaleExpander.extended();
+final icu.LocaleCanonicalizer _canonicalizer =
+    icu.LocaleCanonicalizer.extended();

--- a/pkgs/intl4x/lib/src/locale/locale_ecma.dart
+++ b/pkgs/intl4x/lib/src/locale/locale_ecma.dart
@@ -19,6 +19,9 @@ extension type LocaleJS._(JSObject _) implements JSObject {
   external String? get region;
 }
 
+@JS('Intl.getCanonicalLocales')
+external JSArray<JSString> _getCanonicalLocales(JSString locales);
+
 Locale parseLocale(String s) => LocaleEcma(LocaleJS(s));
 
 class LocaleEcma implements Locale {
@@ -34,6 +37,18 @@ class LocaleEcma implements Locale {
 
   @override
   String? get script => _locale.script;
+
+  @override
+  Locale maximize() => LocaleEcma(_locale.maximize());
+
+  @override
+  Locale minimize() => LocaleEcma(_locale.minimize());
+
+  @override
+  Locale canonicalize() {
+    final canonicalTags = _getCanonicalLocales(_locale.toString().toJS);
+    return LocaleEcma(LocaleJS(canonicalTags.toDart.first.toDart));
+  }
 
   @override
   String toLanguageTag([String separator = '-']) => _locale.toString();

--- a/pkgs/intl4x/test/locale_test.dart
+++ b/pkgs/intl4x/test/locale_test.dart
@@ -68,5 +68,62 @@ void main() {
       expect(a1.hashCode, equals(a2.hashCode));
       expect(a1, isNot(equals(b)));
     });
+
+    test('maximize', () {
+      final en = Locale.parse('en');
+      final enMax = en.maximize();
+      expect(enMax.toLanguageTag(), 'en-Latn-US');
+      expect(enMax.language, 'en');
+      expect(enMax.script, 'Latn');
+      expect(enMax.region, 'US');
+      // Original locale is not mutated
+      expect(en.toLanguageTag(), 'en');
+
+      final zh = Locale.parse('zh');
+      expect(zh.maximize().toLanguageTag(), 'zh-Hans-CN');
+
+      final sr = Locale.parse('sr');
+      expect(sr.maximize().toLanguageTag(), 'sr-Cyrl-RS');
+    });
+
+    test('minimize', () {
+      final enLatnUS = Locale.parse('en-Latn-US');
+      final enMin = enLatnUS.minimize();
+      expect(enMin.toLanguageTag(), 'en');
+      expect(enMin.language, 'en');
+      expect(enMin.script, isNull);
+      expect(enMin.region, isNull);
+      // Original locale is not mutated
+      expect(enLatnUS.toLanguageTag(), 'en-Latn-US');
+
+      final zhHansCN = Locale.parse('zh-Hans-CN');
+      expect(zhHansCN.minimize().toLanguageTag(), 'zh');
+
+      final zhHantTW = Locale.parse('zh-Hant-TW');
+      expect(zhHantTW.minimize().toLanguageTag(), 'zh-TW');
+
+      final withExtension = Locale.parse('en-Latn-US-u-ca-buddhist');
+      expect(withExtension.minimize().toLanguageTag(), 'en-u-ca-buddhist');
+    });
+
+    test('canonicalize', () {
+      final enUS = Locale.parse('en-US');
+      expect(enUS.canonicalize().toLanguageTag(), 'en-US');
+
+      final indonesian = Locale.parse('in');
+      expect(indonesian.canonicalize().toLanguageTag(), 'id');
+
+      final hebrew = Locale.parse('iw');
+      expect(hebrew.canonicalize().toLanguageTag(), 'he');
+
+      final moldavian = Locale.parse('mo');
+      expect(moldavian.canonicalize().toLanguageTag(), 'ro');
+
+      final withExtension = Locale.parse('en-US-u-ca-buddhist');
+      expect(
+        withExtension.canonicalize().toLanguageTag(),
+        'en-US-u-ca-buddhist',
+      );
+    });
   });
 }


### PR DESCRIPTION
Adds `maximize()`, `minimize()`, and `canonicalize()` methods to `Locale` in `package:intl4x`:

- **`maximize()`**: Expands the locale with likely script and region subtags based on CLDR data (using `icu.LocaleExpander.extended().maximize` on native and `Intl.Locale.prototype.maximize()` on web).
- **`minimize()`**: Removes redundant likely subtags (using `icu.LocaleExpander.extended().minimize` on native and `Intl.Locale.prototype.minimize()` on web).
- **`canonicalize()`**: Canonicalizes BCP 47 subtags and extensions, mapping deprecated codes to preferred ones (using `icu.LocaleCanonicalizer.extended().canonicalize` on native and `Intl.getCanonicalLocales` on web).
- Added comprehensive tests for native, browser (Chrome JS), and browser (Chrome Dart2Wasm).
- Updated CHANGELOG.md.

Part of the stack to be merged before the 1.0 release (stacked on `update-icu4x`).

---
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.