### PR TITLE
[intl4x] Add intl4x.brittle_i18n_testing environment define

### DIFF
--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Add more `DateTimeFormat`s.
 - Update `PluralRules.select` to select from plural form options.
 - Add doc examples using dartdoc `{@example}` directive.
-- Add `-Dintl4x.brittle_test_formatting=true` environment define to opt into
-  real formatting in test environments (for golden tests).
+- Add `-Dintl4x.brittle_i18n_testing=true` environment define to opt into
+  real i18n formatting in test environments (for golden tests).
 
 ## 1.0.0-alpha.2
 

--- a/pkgs/intl4x/CHANGELOG.md
+++ b/pkgs/intl4x/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add more `DateTimeFormat`s.
 - Update `PluralRules.select` to select from plural form options.
 - Add doc examples using dartdoc `{@example}` directive.
+- Add `-Dintl4x.brittle_test_formatting=true` environment define to opt into
+  real formatting in test environments (for golden tests).
 
 ## 1.0.0-alpha.2
 

--- a/pkgs/intl4x/lib/src/test_checker.dart
+++ b/pkgs/intl4x/lib/src/test_checker.dart
@@ -4,23 +4,23 @@
 
 import 'dart:async';
 
-/// Whether real formatting is enabled in tests via a compile-time define.
+/// Whether real i18n formatting is enabled in tests via a compile-time define.
 ///
-/// Opting into real formatting in tests makes test assertions brittle to:
+/// Opting into real i18n formatting in tests makes test assertions brittle to:
 /// 1. Biannual Unicode CLDR data updates (e.g. changing spacing or separators).
 /// 2. Differences across browser / OS versions and engine implementations.
 ///
 /// Only use this for golden or snapshot tests where exact output is required.
-const bool allowBrittleFormatting = bool.fromEnvironment(
-  'intl4x.brittle_test_formatting',
+const bool allowBrittleI18nTesting = bool.fromEnvironment(
+  'intl4x.brittle_i18n_testing',
   defaultValue: false,
 );
 
 /// Check if we are in a test environment, by checking for the `#test.declarer`
 /// symbol defined in the zone in which a Dart test runs. The
-/// `#test.allowFormatting` symbol or `-Dintl4x.brittle_test_formatting=true`
+/// `#test.allowFormatting` symbol or `-Dintl4x.brittle_i18n_testing=true`
 /// can be used to override this.
 bool get isInTest =>
-    !allowBrittleFormatting &&
+    !allowBrittleI18nTesting &&
     Zone.current[#test.declarer] != null &&
     !(Zone.current[#test.allowFormatting] as bool? ?? false);

--- a/pkgs/intl4x/lib/src/test_checker.dart
+++ b/pkgs/intl4x/lib/src/test_checker.dart
@@ -4,9 +4,23 @@
 
 import 'dart:async';
 
+/// Whether real formatting is enabled in tests via a compile-time define.
+///
+/// Opting into real formatting in tests makes test assertions brittle to:
+/// 1. Biannual Unicode CLDR data updates (e.g. changing spacing or separators).
+/// 2. Differences across browser / OS versions and engine implementations.
+///
+/// Only use this for golden or snapshot tests where exact output is required.
+const bool _allowBrittleFormatting = bool.fromEnvironment(
+  'intl4x.brittle_test_formatting',
+  defaultValue: false,
+);
+
 /// Check if we are in a test environment, by checking for the `#test.declarer`
 /// symbol defined in the zone in which a Dart test runs. The
-/// `#test.allowFormatting` symbol can be used to override this.
+/// `#test.allowFormatting` symbol or `-Dintl4x.brittle_test_formatting=true`
+/// can be used to override this.
 bool get isInTest =>
+    !_allowBrittleFormatting &&
     Zone.current[#test.declarer] != null &&
     !(Zone.current[#test.allowFormatting] as bool? ?? false);

--- a/pkgs/intl4x/lib/src/test_checker.dart
+++ b/pkgs/intl4x/lib/src/test_checker.dart
@@ -11,7 +11,7 @@ import 'dart:async';
 /// 2. Differences across browser / OS versions and engine implementations.
 ///
 /// Only use this for golden or snapshot tests where exact output is required.
-const bool _allowBrittleFormatting = bool.fromEnvironment(
+const bool allowBrittleFormatting = bool.fromEnvironment(
   'intl4x.brittle_test_formatting',
   defaultValue: false,
 );
@@ -21,6 +21,6 @@ const bool _allowBrittleFormatting = bool.fromEnvironment(
 /// `#test.allowFormatting` symbol or `-Dintl4x.brittle_test_formatting=true`
 /// can be used to override this.
 bool get isInTest =>
-    !_allowBrittleFormatting &&
+    !allowBrittleFormatting &&
     Zone.current[#test.declarer] != null &&
     !(Zone.current[#test.allowFormatting] as bool? ?? false);

--- a/pkgs/intl4x/test/test_checker_test.dart
+++ b/pkgs/intl4x/test/test_checker_test.dart
@@ -8,15 +8,10 @@ import 'package:test/test.dart';
 
 import 'utils.dart';
 
-const bool _allowBrittleFormatting = bool.fromEnvironment(
-  'intl4x.brittle_test_formatting',
-  defaultValue: false,
-);
-
 void main() {
   group('isInTest', () {
     test('reflects brittle formatting compile-time define', () {
-      if (_allowBrittleFormatting) {
+      if (allowBrittleFormatting) {
         expect(isInTest, isFalse);
       } else {
         expect(isInTest, isTrue);
@@ -34,7 +29,7 @@ void main() {
       final formatted = DateTimeFormat.day(
         locale: Locale.parse('en-US'),
       ).format(dateTime);
-      if (_allowBrittleFormatting) {
+      if (allowBrittleFormatting) {
         expect(formatted, '26');
       } else {
         expect(formatted, contains('//en-US'));

--- a/pkgs/intl4x/test/test_checker_test.dart
+++ b/pkgs/intl4x/test/test_checker_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:intl4x/datetime_format.dart';
+import 'package:intl4x/src/test_checker.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+const bool _allowBrittleFormatting = bool.fromEnvironment(
+  'intl4x.brittle_test_formatting',
+  defaultValue: false,
+);
+
+void main() {
+  group('isInTest', () {
+    test('reflects brittle formatting compile-time define', () {
+      if (_allowBrittleFormatting) {
+        expect(isInTest, isFalse);
+      } else {
+        expect(isInTest, isTrue);
+      }
+    });
+
+    test('withFormatting zone override disables isInTest', () {
+      withFormatting(() {
+        expect(isInTest, isFalse);
+      });
+    });
+
+    test('formatting output respects brittle formatting flag', () {
+      final dateTime = DateTime(2026, 3, 26);
+      final formatted = DateTimeFormat.day(
+        locale: Locale.parse('en-US'),
+      ).format(dateTime);
+      if (_allowBrittleFormatting) {
+        expect(formatted, '26');
+      } else {
+        expect(formatted, contains('//en-US'));
+      }
+    });
+  });
+}

--- a/pkgs/intl4x/test/test_checker_test.dart
+++ b/pkgs/intl4x/test/test_checker_test.dart
@@ -10,8 +10,8 @@ import 'utils.dart';
 
 void main() {
   group('isInTest', () {
-    test('reflects brittle formatting compile-time define', () {
-      if (allowBrittleFormatting) {
+    test('reflects brittle i18n testing compile-time define', () {
+      if (allowBrittleI18nTesting) {
         expect(isInTest, isFalse);
       } else {
         expect(isInTest, isTrue);
@@ -24,12 +24,12 @@ void main() {
       });
     });
 
-    test('formatting output respects brittle formatting flag', () {
+    test('formatting output respects brittle i18n testing flag', () {
       final dateTime = DateTime(2026, 3, 26);
       final formatted = DateTimeFormat.day(
         locale: Locale.parse('en-US'),
       ).format(dateTime);
-      if (allowBrittleFormatting) {
+      if (allowBrittleI18nTesting) {
         expect(formatted, '26');
       } else {
         expect(formatted, contains('//en-US'));


### PR DESCRIPTION
Introduce an environment variable for enabling formatting in tests as an alternative to the current Zone value. This makes it more convenient to quickly check the prod-time output in tests.